### PR TITLE
clone variants to environments

### DIFF
--- a/lib/prefab/config_resolver.rb
+++ b/lib/prefab/config_resolver.rb
@@ -65,7 +65,7 @@ module Prefab
           if env_values.any?
             env_value = env_values.first
 
-            # override the top level defautl with env default
+            # override the top level default with env default
             to_store = { match: "env_default", env: env_value.environment, value: env_value.default }
 
             if env_value.namespace_values.any?
@@ -82,6 +82,14 @@ module Prefab
             end
           end
         end
+
+        # feature flags are a funny case
+        # we only define the variants in the default in order to be DRY
+        # but we want to access them in environments, clone them over
+        if to_store[:value].type == :feature_flag
+          to_store[:value].feature_flag.variants = delta.default.feature_flag.variants
+        end
+
         store[key] = to_store
       end
       @lock.with_write_lock do

--- a/test/harness_server.rb
+++ b/test/harness_server.rb
@@ -5,7 +5,6 @@ require 'json'
 
 handler = Rack::Handler::Thin
 
-
 #
 # This is a very lightweight server that allows the compliance harness to excercise the prefab client
 #
@@ -18,6 +17,7 @@ class RackApp
     namespace = props["namespace"]
     environment = props["environment"]
     user_key = props["user_key"]
+    is_feature_flag = !props["feature_flag"].nil?
 
     client = Prefab::Client.new(
       api_key: "1-#{environment}-local_development_api_key", #sets environment
@@ -29,7 +29,14 @@ class RackApp
     puts "Environment #{environment}"
     puts "Namespace #{namespace}"
     puts "Props! #{props}"
-    rtn = client.config_client.get(key).to_s
+    puts "is_feature_flag! #{is_feature_flag}"
+
+    if is_feature_flag
+      puts "EVALFF #{key} #{user_key}"
+      rtn = client.feature_flag_client.get(key, user_key, []).to_s
+    else
+      rtn = client.config_client.get(key).to_s
+    end
     puts "return #{rtn}"
 
     [200, { "Content-Type" => "text/plain" }, rtn]

--- a/test/test_feature_flag_client.rb
+++ b/test/test_feature_flag_client.rb
@@ -32,9 +32,9 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal false,
-                 @client.is_on?(feature, "hashes high", [], flag)
+                 @client.evaluate(feature, "hashes high", [], flag)
     assert_equal true,
-                 @client.is_on?(feature, "hashes low", [], flag)
+                 @client.evaluate(feature, "hashes low", [], flag)
   end
 
   def test_basic_active_inactive
@@ -49,9 +49,9 @@ class TestFeatureFlagClient < Minitest::Test
       default: Prefab::VariantDistribution.new(variant_idx: 1)
     )
     assert_equal true,
-                 @client.is_on?(feature, "hashes high", [], flag)
+                 @client.evaluate(feature, "hashes high", [], flag)
     assert_equal true,
-                 @client.is_on?(feature, "hashes low", [], flag)
+                 @client.evaluate(feature, "hashes low", [], flag)
 
     flag = Prefab::FeatureFlag.new(
       active: false,
@@ -63,9 +63,9 @@ class TestFeatureFlagClient < Minitest::Test
       default: Prefab::VariantDistribution.new(variant_idx: 1)
     )
     assert_equal false,
-                 @client.is_on?(feature, "hashes high", [], flag)
+                 @client.evaluate(feature, "hashes high", [], flag)
     assert_equal false,
-                 @client.is_on?(feature, "hashes low", [], flag)
+                 @client.evaluate(feature, "hashes low", [], flag)
   end
 
   def test_user_targets
@@ -87,13 +87,12 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "user target",
-                 @client.get(feature, "user:1", [], flag)
+                 @client.evaluate(feature, "user:1", [], flag)
     assert_equal "default",
-                 @client.get(feature, "user:2", [], flag)
+                 @client.evaluate(feature, "user:2", [], flag)
     assert_equal "user target",
-                 @client.get(feature, "user:3", [], flag)
+                 @client.evaluate(feature, "user:3", [], flag)
   end
-
 
   def test_inclusion_rule
     feature = "FlagName"
@@ -116,9 +115,9 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "rule target",
-                 @client.get(feature, "user:1", [], flag)
+                 @client.evaluate(feature, "user:1", [], flag)
     assert_equal "default",
-                 @client.get(feature, "user:2", [], flag)
+                 @client.evaluate(feature, "user:2", [], flag)
 
   end
 
@@ -163,9 +162,9 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "rule target",
-                 @client.get(feature, "user:1", [], flag)
+                 @client.evaluate(feature, "user:1", [], flag)
     assert_equal "default",
-                 @client.get(feature, "user:2", [], flag)
+                 @client.evaluate(feature, "user:2", [], flag)
 
   end
 
@@ -207,15 +206,15 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "rule target",
-                 @client.get(feature, "user:1", [], flag)
+                 @client.evaluate(feature, "user:1", [], flag)
     assert_equal "rule target",
-                 @client.get(feature, "user:2", [], flag), "matches segment 1"
+                 @client.evaluate(feature, "user:2", [], flag), "matches segment 1"
     assert_equal "rule target",
-                 @client.get(feature, "user:3", [], flag)
+                 @client.evaluate(feature, "user:3", [], flag)
     assert_equal "rule target",
-                 @client.get(feature, "user:4", [], flag)
+                 @client.evaluate(feature, "user:4", [], flag)
     assert_equal "default",
-                 @client.get(feature, "user:5", [], flag)
+                 @client.evaluate(feature, "user:5", [], flag)
 
   end
 end


### PR DESCRIPTION
harness fleshed out an issue due to the fact that variants are only defined on the default.

Fix this by doing some magic in the resolver.