### PR TITLE
Test Updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       faraday (>= 0.8, < 2)
       hashie (~> 3.5, >= 3.5.2)
       oauth2 (~> 1.0)
-    google-protobuf (3.19.3)
+    google-protobuf (3.21.4)
     googleapis-common-protos-types (1.3.0)
       google-protobuf (~> 3.14)
     grpc (1.43.1)

--- a/test/test_config_client.rb
+++ b/test/test_config_client.rb
@@ -6,7 +6,7 @@ class TestConfigClient < Minitest::Test
       prefab_config_override_dir: "none",
       prefab_config_classpath_dir: "test",
       defaults_env: "unit_tests",
-      local_only: true
+      prefab_datasources: Prefab::Options::DATASOURCES::LOCAL_ONLY
     )
     @config_client = Prefab::ConfigClient.new(MockBaseClient.new(options), 10)
   end

--- a/test/test_config_resolver.rb
+++ b/test/test_config_resolver.rb
@@ -174,7 +174,6 @@ class TestConfigResolver < Minitest::Test
       assert_equal "value", @resolverKeyWith.get("Key:With:Colons")
 
       @resolverKeyWithExtra = resolver_for_namespace("Key:With:Extra", @loader)
-      puts @resolverKeyWithExtra.to_s
       assert_nil @resolverKeyWithExtra.get("Colons")
       assert_nil @resolverKeyWithExtra.get("With:Colons")
       assert_equal "value", @resolverKeyWithExtra.get("Key:With:Colons")


### PR DESCRIPTION
- Update dependencies
  - This fixes a circular-require warning in tests from google libs

- Test fixes
  - test_config_client.rb was using an invalid option `local_only`
  - test/test_config_resolver.rb had errant test output

Note: I considered making `local_only` work, but my gut tells me that we want to keep control in the hands of env vars here. Supporting both means we'd need some way of picking a winner or failing loudly if they disagree, so I've removed `local_only` for now.