### PR TITLE
Improve Feature Flag support

### DIFF
--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -7,7 +7,6 @@ module Prefab
     DEFAULT_CHECKPOINT_FREQ_SEC = 60
     DEFAULT_S3CF_BUCKET = 'http://d2j4ed6ti5snnd.cloudfront.net'
     SSE_READ_TIMEOUT = 300
-    NO_DEFAULT_PROVIDED = :no_default_provided
 
     def initialize(base_client, timeout)
       @base_client = base_client
@@ -75,7 +74,7 @@ module Prefab
                          rows: [Prefab::ConfigRow.new(value: config_value)])
     end
 
-    def get(key, default=NO_DEFAULT_PROVIDED)
+    def get(key, default=Prefab::Client::NO_DEFAULT_PROVIDED)
       config = _get(key)
       config ? value_of(config[:value]) : handle_default(key, default)
     end
@@ -88,7 +87,7 @@ module Prefab
     private
 
     def handle_default(key, default)
-      if default != NO_DEFAULT_PROVIDED
+      if default != Prefab::Client::NO_DEFAULT_PROVIDED
         return default
       end
 

--- a/lib/prefab/config_loader.rb
+++ b/lib/prefab/config_loader.rb
@@ -134,7 +134,7 @@ module Prefab
       criteria = Prefab::Criteria.new(operator: 'ALWAYS_TRUE')
 
       if env_v['criteria']
-        criteria = Prefab::Criteria.new(**env_v['criteria'])
+        criteria = Prefab::Criteria.new(criteria_values(env_v['criteria']))
       end
 
       row = Prefab::ConfigRow.new(
@@ -167,6 +167,14 @@ module Prefab
           rows: [row]
         )
       }
+    end
+
+    def criteria_values(criteria_hash)
+      if RUBY_VERSION < '2.7'
+        criteria_hash.transform_keys(&:to_sym)
+      else
+        criteria_hash
+      end
     end
   end
 end

--- a/test/.prefab.test.config.yaml
+++ b/test/.prefab.test.config.yaml
@@ -8,5 +8,25 @@ sample_to_override: Foo
 prefab.log_level: debug
 unit_tests:
   sample: test sample value
+  enabled_flag: true
+  disabled_flag: false
+  flag_with_a_value:
+    feature_flag: true
+    value: "all-features"
+  in_lookup_key:
+    feature_flag: true
+    value: true
+    criteria:
+      operator: LOOKUP_KEY_IN
+      values:
+        - abc123
+        - xyz987
+  just_my_domain:
+    feature_flag: true
+    value: new-version
+    criteria:
+      operator: PROP_IS_ONE_OF
+      property: domain
+      values: ["prefab.cloud", "example.com"]
 ignored_env:
   sample: ignored value

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -33,6 +33,47 @@ class TestClient < Minitest::Test
     assert_nil client.get("missing_value")
   end
 
+  def test_enabled
+    assert_equal false, @client.enabled?("does_not_exist")
+    assert_equal true, @client.enabled?("enabled_flag")
+    assert_equal false, @client.enabled?("disabled_flag")
+    assert_equal false, @client.enabled?("flag_with_a_value")
+  end
+
+  def test_ff_enabled_with_lookup_key
+    assert_equal false, @client.enabled?("in_lookup_key", "jimmy")
+    assert_equal true, @client.enabled?("in_lookup_key", "abc123")
+    assert_equal true, @client.enabled?("in_lookup_key", "xyz987")
+  end
+
+  def test_ff_get_with_lookup_key
+    assert_nil @client.get("in_lookup_key", "jimmy")
+    assert_equal "DEFAULT", @client.get("in_lookup_key", "jimmy", {}, "DEFAULT")
+
+    assert_equal true, @client.get("in_lookup_key", "abc123")
+    assert_equal true, @client.get("in_lookup_key", "xyz987")
+  end
+
+  def test_ff_enabled_with_attributes
+    assert_equal false, @client.enabled?("just_my_domain", "abc123", { domain: "gmail.com" })
+    assert_equal false, @client.enabled?("just_my_domain", "abc123", { domain: "prefab.cloud" })
+    assert_equal false, @client.enabled?("just_my_domain", "abc123", { domain: "example.com" })
+  end
+
+  def test_ff_get_with_attributes
+    assert_nil @client.get("just_my_domain", "abc123", { domain: "gmail.com" })
+    assert_equal "DEFAULT", @client.get("just_my_domain", "abc123", { domain: "gmail.com" }, "DEFAULT")
+
+    assert_equal "new-version", @client.get("just_my_domain", "abc123", { domain: "prefab.cloud" })
+    assert_equal "new-version", @client.get("just_my_domain", "abc123", { domain: "example.com" })
+  end
+
+
+  def test_getting_feature_flag_value
+    assert_equal false, @client.enabled?("flag_with_a_value")
+    assert_equal "all-features", @client.get("flag_with_a_value")
+  end
+
   private
 
   def new_client(overrides = {})

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -68,7 +68,6 @@ class TestClient < Minitest::Test
     assert_equal "new-version", @client.get("just_my_domain", "abc123", { domain: "example.com" })
   end
 
-
   def test_getting_feature_flag_value
     assert_equal false, @client.enabled?("flag_with_a_value")
     assert_equal "all-features", @client.get("flag_with_a_value")

--- a/test/test_feature_flag_client.rb
+++ b/test/test_feature_flag_client.rb
@@ -9,6 +9,7 @@ class TestFeatureFlagClient < Minitest::Test
     @client = Prefab::FeatureFlagClient.new(@mock_base_client)
     Prefab::FeatureFlagClient.send(:public, :is_on?) #publicize for testing
     Prefab::FeatureFlagClient.send(:public, :segment_match?) #publicize for testing
+    Prefab::FeatureFlagClient.send(:public, :get_variant) #publicize for testing
   end
 
   def test_pct
@@ -38,10 +39,10 @@ class TestFeatureFlagClient < Minitest::Test
 
     # "1FlagNamehashes high" hashes to 86.322% through dist
     assert_equal false,
-                 @client.evaluate(feature, "hashes high", [], flag, variants)
+                 evaluate(feature, "hashes high", [], flag, variants)
     # "1FlagNamehashes low" hashes to 44.547% through dist
     assert_equal true,
-                 @client.evaluate(feature, "hashes low", [], flag, variants)
+                 evaluate(feature, "hashes low", [], flag, variants)
 
   end
 
@@ -57,9 +58,9 @@ class TestFeatureFlagClient < Minitest::Test
       rules: default_ff_rule(2)
     )
     assert_equal true,
-                 @client.evaluate(feature, "hashes high", [], flag, variants)
+                 evaluate(feature, "hashes high", [], flag, variants)
     assert_equal true,
-                 @client.evaluate(feature, "hashes low", [], flag, variants)
+                 evaluate(feature, "hashes low", [], flag, variants)
 
     variants = [
       Prefab::FeatureFlagVariant.new(bool: false),
@@ -71,9 +72,9 @@ class TestFeatureFlagClient < Minitest::Test
       rules: default_ff_rule(2)
     )
     assert_equal false,
-                 @client.evaluate(feature, "hashes high", [], flag, variants)
+                 evaluate(feature, "hashes high", [], flag, variants)
     assert_equal false,
-                 @client.evaluate(feature, "hashes low", [], flag, variants)
+                 evaluate(feature, "hashes low", [], flag, variants)
   end
 
   def test_inclusion_rule
@@ -109,9 +110,9 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:1", [], flag, variants)
+                 evaluate(feature, "user:1", [], flag, variants)
     assert_equal "default",
-                 @client.evaluate(feature, "user:2", [], flag, variants)
+                 evaluate(feature, "user:2", [], flag, variants)
 
   end
 
@@ -149,13 +150,13 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "default",
-                 @client.evaluate(feature, "user:1", { email: "not@example.com" }, flag, variants)
+                 evaluate(feature, "user:1", { email: "not@example.com" }, flag, variants)
     assert_equal "default",
-                 @client.evaluate(feature, "user:2", {}, flag, variants)
+                 evaluate(feature, "user:2", {}, flag, variants)
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:2", { email: "b@example.com" }, flag, variants)
+                 evaluate(feature, "user:2", { email: "b@example.com" }, flag, variants)
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:2", { "email" => "b@example.com" }, flag, variants)
+                 evaluate(feature, "user:2", { "email" => "b@example.com" }, flag, variants)
 
   end
 
@@ -224,9 +225,9 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:1", [], flag, variants)
+                 evaluate(feature, "user:1", [], flag, variants)
     assert_equal "default",
-                 @client.evaluate(feature, "user:2", [], flag, variants)
+                 evaluate(feature, "user:2", [], flag, variants)
 
   end
 
@@ -286,16 +287,20 @@ class TestFeatureFlagClient < Minitest::Test
     )
 
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:1", [], flag, variants)
+                 evaluate(feature, "user:1", [], flag, variants)
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:2", [], flag, variants), "matches segment 1"
+                 evaluate(feature, "user:2", [], flag, variants), "matches segment 1"
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:3", [], flag, variants)
+                 evaluate(feature, "user:3", [], flag, variants)
     assert_equal "rule target",
-                 @client.evaluate(feature, "user:4", [], flag, variants)
+                 evaluate(feature, "user:4", [], flag, variants)
     assert_equal "default",
-                 @client.evaluate(feature, "user:5", [], flag, variants)
+                 evaluate(feature, "user:5", [], flag, variants)
 
   end
 
+  def evaluate(feature_name, lookup_key, attributes, flag, variants)
+    variant = @client.get_variant(feature_name, lookup_key, attributes, flag, variants)
+    @client.value_of_variant(variant)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,3 +76,14 @@ def with_env(key, value)
 ensure
   ENV[key] = old_value
 end
+
+def new_client(overrides = {})
+  options = Prefab::Options.new(**{
+    prefab_config_override_dir: "none",
+    prefab_config_classpath_dir: "test",
+    defaults_env: "unit_tests",
+    prefab_datasources: Prefab::Options::DATASOURCES::LOCAL_ONLY
+  }.merge(overrides))
+
+  Prefab::Client.new(options)
+end


### PR DESCRIPTION
- Adds top-level `$prefab.enabled?` for feature-flag checks
- Supports getting ff values in `$prefab.get`
- Support feature flag criteria in xxx.config.yaml files
- Fixes bug with `feature_is_on_for?` where always-true flags could
  return false (due to doubly-evaluating the variant)

Note that this doesn't include testing for ff criteria for

- segments
- lookup key not in
- property ends with one of
- property does not end with one of

We can add those on as we wish