### PR TITLE
Fix some test-related warnings

### DIFF
--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -28,8 +28,8 @@ class TestClient < Minitest::Test
       assert_nil @client.get("missing_value")
     end
 
-    assert_match /No value found for key/, err.message
-    assert_match /on_no_default/, err.message
+    assert_match(/No value found for key/, err.message)
+    assert_match(/on_no_default/, err.message)
 
     # you can opt-in to return `nil` instead
     client = new_client(on_no_default: Prefab::Options::ON_NO_DEFAULT::RETURN_NIL)

--- a/test/test_config_client.rb
+++ b/test/test_config_client.rb
@@ -29,7 +29,7 @@ class TestConfigClient < Minitest::Test
       Prefab::Client.new(options).config_client.get("anything")
     end
 
-    assert_match /couldn't initialize in 0.01 second timeout/, err.message
+    assert_match(/couldn't initialize in 0.01 second timeout/, err.message)
   end
 
   def test_invalid_api_key_error
@@ -41,7 +41,7 @@ class TestConfigClient < Minitest::Test
       Prefab::Client.new(options).config_client.get("anything")
     end
 
-    assert_match /No API key/, err.message
+    assert_match(/No API key/, err.message)
 
     options = Prefab::Options.new(
       api_key: "invalid",
@@ -51,6 +51,6 @@ class TestConfigClient < Minitest::Test
       Prefab::Client.new(options).config_client.get("anything")
     end
 
-    assert_match /format is invalid/, err.message
+    assert_match(/format is invalid/, err.message)
   end
 end


### PR DESCRIPTION
I introduced these with recent tests

> warning: ambiguity between regexp and two divisions
