### PR TITLE
Jd/logging

### DIFF
--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -19,7 +19,7 @@ module Prefab
     end
 
     def add_internal(severity, message = nil, progname = nil, loc, &block)
-      path = get_path(loc.absolute_path, loc.base_label)
+      path = get_loc_path(loc)
       log_internal(message, path, progname, severity, &block)
     end
 
@@ -119,6 +119,11 @@ module Prefab
         memo
       end
       val(closest_log_level_match)
+    end
+
+    def get_loc_path(loc)
+      loc_path = loc.absolute_path || loc.to_s
+      get_path(loc_path, loc.base_label)
     end
 
     # sanitize & clean the path of the caller so the key

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -131,10 +131,9 @@ module Prefab
     def get_path(absolute_path, base_label)
       path = (absolute_path || UNKNOWN).dup
       path.slice! Dir.pwd
+      path.gsub!(/(.*)?(?=\/lib)/im, "") # replace everything before first lib
 
-      path.gsub!(/.*?(?=\/lib\/)/im, "")
-
-      path = path.gsub("/", SEP).gsub(".rb", "") + SEP + base_label
+      path = path.gsub("/", SEP).gsub(/.rb.*/, "") + SEP + base_label
       path.slice! ".lib"
       path.slice! SEP
       path

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 class TestCLogger < Minitest::Test
   def setup
     Prefab::LoggerClient.send(:public, :get_path)
+    Prefab::LoggerClient.send(:public, :get_loc_path)
     Prefab::LoggerClient.send(:public, :level_of)
     @logger = Prefab::LoggerClient.new($stdout)
   end
@@ -16,6 +17,24 @@ class TestCLogger < Minitest::Test
     assert_equal "active_support.log_subscriber.info",
                  @logger.get_path("/Users/jdwyah/.rvm/gems/ruby-2.3.3@forcerank/gems/activesupport-4.1.16/lib/active_support/log_subscriber.rb",
                                   "info")
+  end
+
+  def test_loc_resolution
+    backtrace_location = Struct.new(:absolute_path, :base_label, :string) do
+      def to_s
+        string
+      end
+    end # https://ruby-doc.org/core-3.0.0/Thread/Backtrace/Location.html
+
+    # verify that even if the Thread::Backtrace::Location does not have an absolute_location, we do our best
+    assert_equal "active_support.log_subscriber.info",
+                 @logger.get_loc_path(backtrace_location.new(nil,
+                                                             "info",
+                                                             "/Users/jeffdwyer/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.2.4/lib/active_support/log_subscriber.rb:130:in `info'"))
+    assert_equal "test_l.info",
+                 @logger.get_loc_path(backtrace_location.new("/Users/jdwyah/Documents/workspace/RateLimitInc/prefab-cloud-ruby/lib/test_l.rb",
+                                                             "info",
+                                                             "/Users/jeffdwyer/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.2.4/lib/active_support/log_subscriber.rb:130:in `info'"))
   end
 
   def test_level_of

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -17,6 +17,9 @@ class TestCLogger < Minitest::Test
     assert_equal "active_support.log_subscriber.info",
                  @logger.get_path("/Users/jdwyah/.rvm/gems/ruby-2.3.3@forcerank/gems/activesupport-4.1.16/lib/active_support/log_subscriber.rb",
                                   "info")
+    assert_equal "active_support.log_subscriber.info",
+                 @logger.get_path("/Users/jeffdwyer/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.2.4/lib/active_support/log_subscriber.rb:130:in `info'",
+                                  "info")
   end
 
   def test_loc_resolution


### PR DESCRIPTION
very open to more investigate here. 

I am quite perplexed, but it seems the https://ruby-doc.org/core-3.0.0/Thread/Backtrace/Location.html we get from the rails log_subscriber has a nil absolute_path. 

This PR does not address the fact that rails internal logging will still report as `active_support.log_subscriber` instead of its original location.  