### PR TITLE
remove parsing of projectID from apikey

### DIFF
--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -5,7 +5,7 @@ module Prefab
     BASE_SLEEP_SEC = 0.5
     NO_DEFAULT_PROVIDED = :no_default_provided
 
-    attr_reader :project_id, :shared_cache, :stats, :namespace, :interceptor, :api_key, :prefab_api_url, :options
+    attr_reader :shared_cache, :stats, :namespace, :interceptor, :api_key, :prefab_api_url, :options
 
     def initialize(options = Prefab::Options.new)
       @options = options
@@ -15,12 +15,10 @@ module Prefab
       @stubs = {}
 
       if @options.local_only?
-        @project_id = 0
         log_internal Logger::INFO, "Prefab Running in Local Mode"
       else
         @api_key = @options.api_key
-        raise Prefab::Errors::InvalidApiKeyError.new(@api_key) if @api_key.nil? || @api_key.empty? || api_key.count("-") != 3
-        @project_id = @api_key.split("-")[0].to_i # unvalidated, but that's ok. APIs only listen to the actual passwd
+        raise Prefab::Errors::InvalidApiKeyError.new(@api_key) if @api_key.nil? || @api_key.empty? || api_key.count("-") < 1
         @interceptor = Prefab::AuthInterceptor.new(@api_key)
         @prefab_api_url = @options.prefab_api_url
         @prefab_grpc_url = @options.prefab_grpc_url
@@ -80,10 +78,6 @@ module Prefab
         reset!
         retry
       end
-    end
-
-    def cache_key(post_fix)
-      "prefab:#{project_id}:#{post_fix}"
     end
 
     def reset!

--- a/lib/prefab/feature_flag_client.rb
+++ b/lib/prefab/feature_flag_client.rb
@@ -116,7 +116,7 @@ module Prefab
     end
 
     def get_user_pct(feature, lookup_key)
-      to_hash = "#{@base_client.project_id}#{feature}#{lookup_key}"
+      to_hash = "#{feature}#{lookup_key}"
       int_value = Murmur3.murmur3_32(to_hash)
       int_value / MAX_32_FLOAT
     end

--- a/test/test_feature_flag_client.rb
+++ b/test/test_feature_flag_client.rb
@@ -37,10 +37,10 @@ class TestFeatureFlagClient < Minitest::Test
     # weights above chosen to be 86% in variant_idx 2. and 14% in variant_idx 1.
     # since hashes high is 86.32 > 86 it just falls outside the 86% range and gets false
 
-    # "1FlagNamehashes high" hashes to 86.322% through dist
+    # "FlagNamevery high hash" hashes to 88.8602812% through dist
     assert_equal false,
-                 evaluate(feature, "hashes high", [], flag, variants)
-    # "1FlagNamehashes low" hashes to 44.547% through dist
+                 evaluate(feature, "very high hash", [], flag, variants)
+    # "FlagNamehashes low" hashes to 42.7934% through dist
     assert_equal true,
                  evaluate(feature, "hashes low", [], flag, variants)
 


### PR DESCRIPTION
simplify APIKEY validation

This is a breaking change to flag hashing because we were including it in the hash.

The other usages were incidental and unimportant.