### PR TITLE
use new, simpler checkpoint_url

### DIFF
--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -149,8 +149,7 @@ module Prefab
     end
 
     def load_checkpoint_api_cdn
-      key_hash = Murmur3.murmur3_32(@base_client.api_key)
-      url = "#{@options.url_for_api_cdn}/api/v1/configs/0/#{key_hash}/0"
+      url = "#{@options.url_for_api_cdn}/api/v1/configs/0"
       conn = if Faraday::VERSION[0].to_i >= 2
                Faraday.new(url) do |conn|
                  conn.request :authorization, :basic, AUTH_USER, @base_client.api_key


### PR DESCRIPTION
we have a new, simpler url to get checkpoints from.

We're relying purely on the auth token here to figure out which project & env to return. 
And we're using the Vary header to prevent erroneous caching. 