### PR TITLE
Jd/logging config format fix

### DIFF
--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -4,7 +4,7 @@ module Prefab
 
     SEP = "."
     BASE_KEY = "log-level"
-    UNKNOWN = "unknown"
+    UNKNOWN_PATH = "unknown."
 
     LOG_LEVEL_LOOKUPS = {
       Prefab::LogLevel::NOT_SET_LOG_LEVEL => Logger::DEBUG,
@@ -36,7 +36,7 @@ module Prefab
     def log_internal(message, path, progname, severity, &block)
       level = level_of(path)
       progname = "#{path}: #{progname}"
-      severity ||= UNKNOWN
+      severity ||= Logger::UNKNOWN
       if @logdev.nil? || severity < level || @silences[local_log_id]
         return true
       end
@@ -139,7 +139,7 @@ module Prefab
     # sanitize & clean the path of the caller so the key
     # looks like log_level.app.models.user
     def get_path(absolute_path, base_label)
-      path = (absolute_path || UNKNOWN).dup
+      path = (absolute_path || UNKNOWN_PATH).dup
       path.slice! Dir.pwd
       path.gsub!(/(.*)?(?=\/lib)/im, "") # replace everything before first lib
 

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -119,7 +119,7 @@ module Prefab
 
     # Find the closest match to 'log_level.path' in config
     def level_of(path)
-      closest_log_level_match = @config_client.get(BASE_KEY, Prefab::LogLevel::WARN)
+      closest_log_level_match = @config_client.get(BASE_KEY, :WARN)
       path.split(SEP).inject([BASE_KEY]) do |memo, n|
         memo << n
         val = @config_client.get(memo.join(SEP), nil)
@@ -128,7 +128,8 @@ module Prefab
         end
         memo
       end
-      LOG_LEVEL_LOOKUPS[closest_log_level_match]
+      closest_log_level_match_int = Prefab::LogLevel.resolve(closest_log_level_match)
+      LOG_LEVEL_LOOKUPS[closest_log_level_match_int]
     end
 
     def get_loc_path(loc)
@@ -154,7 +155,7 @@ module Prefab
   # since it may log
   class BootstrappingConfigClient
     def get(key, default = nil)
-      ENV["PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL"] ? Prefab::LogLevel.resolve(ENV["PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL"].upcase.to_sym) : default
+      ENV["PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL"] ? ENV["PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL"].upcase.to_sym : default
     end
   end
 end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -95,12 +95,11 @@ class TestCLogger < Minitest::Test
       pattern.match(arg)
     end
 
-    mock_logdev.expect :!=, false, [String]
     calls.times.each do
       mock_logdev.expect(:nil?, false)
     end
 
-    logger = Prefab::LoggerClient.new(mock_logdev)
+    logger = Prefab::LoggerClient.new($stdout)
     logger.instance_variable_set('@logdev', mock_logdev)
     logger.set_config_client(MockConfigClient.new(configs))
     [logger, mock_logdev]

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -69,20 +69,6 @@ class TestCLogger < Minitest::Test
   end
 
   def test_log_internal
-    mockLogOut = Minitest::Mock.new
-    mockLogOut.expect :write, nil do |arg|
-      /W, \[.*\]  WARN -- test.path: : test message/.match(arg)
-    end
-
-    mockLogOut.expect :!=, false, [String]
-    mockLogOut.expect :nil?, false
-
-    @logger = Prefab::LoggerClient.new(mockLogOut)
-    @logger.instance_variable_set('@logdev', mockLogOut)
-    @logger.log_internal("test message", "test.path", "", Logger::WARN)
-  end
-
-  def test_log_internal
     logger, mock_logdev = mock_logger_expecting /W, \[.*\]  WARN -- test.path: : test message/
     logger.log_internal("test message", "test.path", "", Logger::WARN)
     mock_logdev.verify

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -20,6 +20,9 @@ class TestCLogger < Minitest::Test
     assert_equal "active_support.log_subscriber.info",
                  @logger.get_path("/Users/jeffdwyer/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.2.4/lib/active_support/log_subscriber.rb:130:in `info'",
                                   "info")
+    assert_equal "unknown.info",
+                 @logger.get_path(nil,
+                                  "info")
   end
 
   def test_loc_resolution


### PR DESCRIPTION
Fix up to log levels. 

Improve test coverage of logger client. ConfigValue.log_level returns `:INFO` not an integer constant. 