### PR TITLE
Support specifying a log prefix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ end
 
 group :test do
   gem "minitest"
+  gem "minitest-focus"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       rake (~> 13.0)
     mini_portile2 (2.8.0)
     minitest (5.16.2)
+    minitest-focus (1.3.1)
+      minitest (>= 4, < 6)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -119,6 +121,7 @@ DEPENDENCIES
   juwelier (~> 2.4.9)
   ld-eventsource
   minitest
+  minitest-focus
   rdoc
   simplecov
   thin

--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -52,7 +52,7 @@ module Prefab
     end
 
     def log_internal(level, msg, path = nil)
-      log.log_internal msg, path || @options.log_prefix, nil, level
+      log.log_internal msg, path, nil, level
     end
 
     def request(service, method, req_options: {}, params: {})

--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -47,7 +47,8 @@ module Prefab
     end
 
     def log
-      @logger_client ||= Prefab::LoggerClient.new(@options.logdev, formatter: @options.log_formatter)
+      @logger_client ||= Prefab::LoggerClient.new(@options.logdev, formatter: @options.log_formatter,
+                                                                   prefix: @options.log_prefix)
     end
 
     def log_internal(level, msg, path = "cloud.prefab.client")

--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -51,8 +51,8 @@ module Prefab
                                                                    prefix: @options.log_prefix)
     end
 
-    def log_internal(level, msg, path = "cloud.prefab.client")
-      log.log_internal msg, path, nil, level
+    def log_internal(level, msg, path = nil)
+      log.log_internal msg, path || @options.log_prefix, nil, level
     end
 
     def request(service, method, req_options: {}, params: {})

--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -189,7 +189,7 @@ module Prefab
       if @config_loader.highwater_mark > starting_highwater_mark
         @base_client.log_internal Logger::INFO, "Found new checkpoint with highwater id #{@config_loader.highwater_mark} from #{source} in project #{project_id} environment: #{project_env_id} and namespace: '#{@namespace}'"
       else
-        @base_client.log_internal Logger::DEBUG, "Checkpoint with highwater id #{@config_loader.highwater_mark} from #{source}. No changes.", "#{Prefab::LoggerClient::INTERNAL_PREFIX}.load_configs"
+        @base_client.log_internal Logger::DEBUG, "Checkpoint with highwater id #{@config_loader.highwater_mark} from #{source}. No changes.", "load_configs"
       end
       @base_client.stats.increment("prefab.config.checkpoint.load")
       @config_resolver.update

--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -189,7 +189,7 @@ module Prefab
       if @config_loader.highwater_mark > starting_highwater_mark
         @base_client.log_internal Logger::INFO, "Found new checkpoint with highwater id #{@config_loader.highwater_mark} from #{source} in project #{project_id} environment: #{project_env_id} and namespace: '#{@namespace}'"
       else
-        @base_client.log_internal Logger::DEBUG, "Checkpoint with highwater id #{@config_loader.highwater_mark} from #{source}. No changes.", "prefab.config_client.load_configs"
+        @base_client.log_internal Logger::DEBUG, "Checkpoint with highwater id #{@config_loader.highwater_mark} from #{source}. No changes.", "#{Prefab::LoggerClient::INTERNAL_PREFIX}.load_configs"
       end
       @base_client.stats.increment("prefab.config.checkpoint.load")
       @config_resolver.update

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -5,6 +5,7 @@ module Prefab
     SEP = "."
     BASE_KEY = "log-level"
     UNKNOWN_PATH = "unknown."
+    INTERNAL_PREFIX = "cloud.prefab.client"
 
     LOG_LEVEL_LOOKUPS = {
       Prefab::LogLevel::NOT_SET_LOG_LEVEL => Logger::DEBUG,
@@ -38,7 +39,7 @@ module Prefab
       if path
         path = "#{@prefix}#{@prefix && '.'}#{path}"
       else
-        path = "cloud.prefab.client"
+        path = INTERNAL_PREFIX
       end
 
       level = level_of(path)

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -25,23 +25,24 @@ module Prefab
       @prefix = prefix
     end
 
-    def add(severity, message = nil, progname = nil)
-      loc = caller_locations(1, 1)[0]
-      add_internal(severity, message, progname, loc)
-    end
-
-    def add_internal(severity, message = nil, progname = nil, loc, &block)
+    def add(severity, message = nil, progname = nil, loc, &block)
       path = get_loc_path(loc)
-      log_internal(message, path, progname, severity, &block)
+      path = "#{@prefix}#{@prefix && '.'}#{path}"
+
+      log(message, path, progname, severity, &block)
     end
 
     def log_internal(message, path = nil, progname, severity, &block)
       if path
-        path = "#{@prefix}#{@prefix && '.'}#{path}"
+        path = "#{INTERNAL_PREFIX}.#{path}"
       else
         path = INTERNAL_PREFIX
       end
 
+      log(message, path, progname, severity, &block)
+    end
+
+    def log(message, path, progname, severity, &block)
       level = level_of(path)
       progname = "#{path}: #{progname}"
       severity ||= Logger::UNKNOWN
@@ -65,23 +66,23 @@ module Prefab
     end
 
     def debug(progname = nil, &block)
-      add_internal(DEBUG, nil, progname, caller_locations(1, 1)[0], &block)
+      add(DEBUG, nil, progname, caller_locations(1, 1)[0], &block)
     end
 
     def info(progname = nil, &block)
-      add_internal(INFO, nil, progname, caller_locations(1, 1)[0], &block)
+      add(INFO, nil, progname, caller_locations(1, 1)[0], &block)
     end
 
     def warn(progname = nil, &block)
-      add_internal(WARN, nil, progname, caller_locations(1, 1)[0], &block)
+      add(WARN, nil, progname, caller_locations(1, 1)[0], &block)
     end
 
     def error(progname = nil, &block)
-      add_internal(ERROR, nil, progname, caller_locations(1, 1)[0], &block)
+      add(ERROR, nil, progname, caller_locations(1, 1)[0], &block)
     end
 
     def fatal(progname = nil, &block)
-      add_internal(FATAL, nil, progname, caller_locations(1, 1)[0], &block)
+      add(FATAL, nil, progname, caller_locations(1, 1)[0], &block)
     end
 
     def debug?

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -34,9 +34,15 @@ module Prefab
       log_internal(message, path, progname, severity, &block)
     end
 
-    def log_internal(message, path, progname, severity, &block)
+    def log_internal(message, path = nil, progname, severity, &block)
+      if path
+        path = "#{@prefix}#{@prefix && '.'}#{path}"
+      else
+        path = "cloud.prefab.client"
+      end
+
       level = level_of(path)
-      progname = "#{@prefix}#{@prefix && '.'}#{path}: #{progname}"
+      progname = "#{path}: #{progname}"
       severity ||= Logger::UNKNOWN
       if @logdev.nil? || severity < level || @silences[local_log_id]
         return true

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -16,11 +16,12 @@ module Prefab
       Prefab::LogLevel::FATAL => Logger::FATAL
     }
 
-    def initialize(logdev, formatter: nil)
+    def initialize(logdev, formatter: nil, prefix: nil)
       super(logdev)
       self.formatter = formatter
       @config_client = BootstrappingConfigClient.new
-      @silences = Concurrent::Map.new(:initial_capacity => 2)
+      @silences = Concurrent::Map.new(initial_capacity: 2)
+      @prefix = prefix
     end
 
     def add(severity, message = nil, progname = nil)
@@ -35,7 +36,7 @@ module Prefab
 
     def log_internal(message, path, progname, severity, &block)
       level = level_of(path)
-      progname = "#{path}: #{progname}"
+      progname = "#{@prefix}#{@prefix && '.'}#{path}: #{progname}"
       severity ||= Logger::UNKNOWN
       if @logdev.nil? || severity < level || @silences[local_log_id]
         return true

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -42,7 +42,7 @@ module Prefab
       shared_cache: NoopCache.new, # Something that quacks like Rails.cache ideally memcached
       namespace: "",
       log_formatter: DEFAULT_LOG_FORMATTER,
-      log_prefix: "cloud.prefab.client",
+      log_prefix: nil,
       prefab_api_url: ENV["PREFAB_API_URL"] || 'https://api.prefab.cloud',
       prefab_grpc_url: ENV["PREFAB_GRPC_URL"] || 'grpc.prefab.cloud:443',
       on_no_default: ON_NO_DEFAULT::RAISE, # options :raise, :warn_and_return_nil,

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -42,7 +42,7 @@ module Prefab
       shared_cache: NoopCache.new, # Something that quacks like Rails.cache ideally memcached
       namespace: "",
       log_formatter: DEFAULT_LOG_FORMATTER,
-      log_prefix: nil,
+      log_prefix: "cloud.prefab.client",
       prefab_api_url: ENV["PREFAB_API_URL"] || 'https://api.prefab.cloud',
       prefab_grpc_url: ENV["PREFAB_GRPC_URL"] || 'grpc.prefab.cloud:443',
       on_no_default: ON_NO_DEFAULT::RAISE, # options :raise, :warn_and_return_nil,

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
+
 module Prefab
   class Options
     attr_reader :api_key
     attr_reader :logdev
+    attr_reader :log_prefix
     attr_reader :log_formatter
     attr_reader :stats
     attr_reader :shared_cache
@@ -40,6 +42,7 @@ module Prefab
       shared_cache: NoopCache.new, # Something that quacks like Rails.cache ideally memcached
       namespace: "",
       log_formatter: DEFAULT_LOG_FORMATTER,
+      log_prefix: nil,
       prefab_api_url: ENV["PREFAB_API_URL"] || 'https://api.prefab.cloud',
       prefab_grpc_url: ENV["PREFAB_GRPC_URL"] || 'grpc.prefab.cloud:443',
       on_no_default: ON_NO_DEFAULT::RAISE, # options :raise, :warn_and_return_nil,
@@ -59,6 +62,7 @@ module Prefab
       @shared_cache = shared_cache
       @namespace = namespace
       @log_formatter = log_formatter
+      @log_prefix = log_prefix
       @prefab_api_url = prefab_api_url
       @prefab_grpc_url = prefab_grpc_url
       @on_no_default = on_no_default

--- a/lib/prefab/sse_logger.rb
+++ b/lib/prefab/sse_logger.rb
@@ -2,7 +2,7 @@
 module Prefab
   class SseLogger < InternalLogger
     def initialize(logger)
-      super("cloud.prefab.config.sse", logger)
+      super("sse", logger)
     end
 
     # The SSE::Client warns on a perfectly normal stream disconnect, recast to info

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'minitest/autorun'
+require "minitest/focus"
 require 'prefab-cloud-ruby'
 
 class MockBaseClient

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -91,7 +91,7 @@ class TestCLogger < Minitest::Test
   end
 
   def test_logging_with_prefix
-    prefix = 'cloud.prefab.web'
+    prefix = 'my.own.prefix'
     message = 'this is a test'
 
     io = StringIO.new

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -70,23 +70,44 @@ class TestCLogger < Minitest::Test
   end
 
   def test_log_internal
-    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : test message/)
+    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- cloud.prefab.client.test.path: : test message/)
     logger.log_internal("test message", "test.path", "", Logger::WARN)
     mock_logdev.verify
   end
 
   def test_log_internal_unknown
-    logger, mock_logdev = mock_logger_expecting(/A, \[.*\]   ANY -- test.path: : test message/)
+    logger, mock_logdev = mock_logger_expecting(/A, \[.*\]   ANY -- cloud.prefab.client.test.path: : test message/)
     logger.log_internal("test message", "test.path", "", Logger::UNKNOWN)
     mock_logdev.verify
   end
 
   def test_log_internal_silencing
-    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : should log/, calls: 2)
+    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- cloud.prefab.client.test.path: : should log/, calls: 2)
     logger.silence do
       logger.log_internal("should not log", "test.path", "", Logger::WARN)
     end
     logger.log_internal("should log", "test.path", "", Logger::WARN)
+    mock_logdev.verify
+  end
+
+  def test_log
+    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : test message/)
+    logger.log("test message", "test.path", "", Logger::WARN)
+    mock_logdev.verify
+  end
+
+  def test_log_unknown
+    logger, mock_logdev = mock_logger_expecting(/A, \[.*\]   ANY -- test.path: : test message/)
+    logger.log("test message", "test.path", "", Logger::UNKNOWN)
+    mock_logdev.verify
+  end
+
+  def test_log_silencing
+    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : should log/, calls: 2)
+    logger.silence do
+      logger.log("should not log", "test.path", "", Logger::WARN)
+    end
+    logger.log("should log", "test.path", "", Logger::WARN)
     mock_logdev.verify
   end
 

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 
 class TestCLogger < Minitest::Test
@@ -69,24 +70,42 @@ class TestCLogger < Minitest::Test
   end
 
   def test_log_internal
-    logger, mock_logdev = mock_logger_expecting /W, \[.*\]  WARN -- test.path: : test message/
+    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : test message/)
     logger.log_internal("test message", "test.path", "", Logger::WARN)
     mock_logdev.verify
   end
 
   def test_log_internal_unknown
-    logger, mock_logdev = mock_logger_expecting /A, \[.*\]   ANY -- test.path: : test message/
+    logger, mock_logdev = mock_logger_expecting(/A, \[.*\]   ANY -- test.path: : test message/)
     logger.log_internal("test message", "test.path", "", Logger::UNKNOWN)
     mock_logdev.verify
   end
 
   def test_log_internal_silencing
-    logger, mock_logdev = mock_logger_expecting /W, \[.*\]  WARN -- test.path: : should log/, calls: 2
+    logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : should log/, calls: 2)
     logger.silence do
       logger.log_internal("should not log", "test.path", "", Logger::WARN)
     end
     logger.log_internal("should log", "test.path", "", Logger::WARN)
     mock_logdev.verify
+  end
+
+  def test_logging_with_prefix
+    prefix = 'cloud.prefab.web'
+    message = 'this is a test'
+
+    io = StringIO.new
+    options = Prefab::Options.new(logdev: io, log_prefix: prefix, prefab_datasources: Prefab::Options::DATASOURCES::LOCAL_ONLY)
+    prefab = Prefab::Client.new(options)
+
+    prefixed_logger = prefab.log
+    prefixed_logger.error message
+
+    assert_logged io.string, 'ERROR', "#{prefix}.test.test_logger.test_logging_with_prefix", message
+  end
+
+  def assert_logged(log_line, level, path, message)
+    assert_match(/#{level} \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-\+]?\d+:  #{path}: #{message}\n/, log_line)
   end
 
   def mock_logger_expecting pattern, configs = {}, calls: 1


### PR DESCRIPTION
I had to implement this in options. The suggested implementation of `prefab.logger(prefix: 'cloud.prefab.web')` won't work because the client's `log` is memoized and used internally on init before this `prefab.logger(prefix: 'cloud.prefab.web')` could be called.

This also reserves `log_internal` for client-internals (we're using `log` for common logic now)