### PR TITLE
Fix progname usage and remove additional whitespace

### DIFF
--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -43,15 +43,13 @@ module Prefab
     end
 
     def log(message, path, progname, severity, &block)
-      level = level_of(path)
-      progname = "#{path}: #{progname}"
       severity ||= Logger::UNKNOWN
-      if @logdev.nil? || severity < level || @silences[local_log_id]
+      if @logdev.nil? || severity < level_of(path) || @silences[local_log_id]
         return true
       end
-      if progname.nil?
-        progname = @progname
-      end
+
+      progname = "#{path}: #{progname || @progname}"
+
       if message.nil?
         if block_given?
           message = yield
@@ -60,6 +58,7 @@ module Prefab
           progname = @progname
         end
       end
+
       @logdev.write(
         format_message(format_severity(severity), Time.now, progname, message))
       true

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -19,7 +19,7 @@ module Prefab
     attr_reader :prefab_envs
 
     DEFAULT_LOG_FORMATTER = proc { |severity, datetime, progname, msg|
-      "#{severity.ljust(5)} #{datetime}: #{progname} #{msg}\n"
+      "#{severity.ljust(5)} #{datetime}:#{" " if progname}#{progname} #{msg}\n"
     }
 
     module ON_INITIALIZATION_FAILURE


### PR DESCRIPTION
- The `progname` set in options wouldn't be output properly because the `||=` was after assignment
- `DEFAULT_LOG_FORMATTER` showed an extra space when `progname` wasn't set.
- This also has some minor optimizations to avoid some assignment if `@logdev` is nil.
