### PR TITLE
Report log paths and usages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'googleapis-common-protos-types', platforms: :ruby
 gem 'google-protobuf', platforms: :ruby
 gem 'grpc', platforms: :ruby
 gem 'ld-eventsource'
+gem 'uuid'
 
 group :development do
   gem 'benchmark-ips'

--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :test do
   gem 'minitest'
   gem 'minitest-focus'
   gem 'minitest-reporters'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     simplecov-html (0.12.3)
     systemu (2.6.5)
     thread_safe (0.3.6)
+    timecop (0.9.4)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8)
@@ -132,6 +133,7 @@ DEPENDENCIES
   minitest-reporters
   rdoc
   simplecov
+  timecop
   uuid
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     mini_portile2 (2.8.0)
     minitest (5.16.2)
     minitest-focus (1.3.1)
@@ -103,10 +105,13 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    systemu (2.6.5)
     thread_safe (0.3.6)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
 
 PLATFORMS
   ruby
@@ -127,6 +132,7 @@ DEPENDENCIES
   minitest-reporters
   rdoc
   simplecov
+  uuid
 
 BUNDLED WITH
    2.3.5

--- a/README.md
+++ b/README.md
@@ -3,18 +3,20 @@ Ruby Client for Prefab FeatureFlags, Config as a Service: https://www.prefab.clo
 
 ```ruby
 client = Prefab::Client.new
-@feature_flags = client.feature_flag_client
 
-# Create a flag that is on for 10% of traffic, the entire beta group and user:1
-@feature_flags.upsert(Prefab::FeatureFlag.new(feature: "MyFeature", pct: 0.1, whitelisted: ["betas", "user:1"]))
+lookup_key = "user-123"
+identity_attributes = {
+  team_id: 432,
+  user_id: 123,
+  subscription_level: 'pro',
+  email: "alice@example.com"
+}
 
-# Use Flags By Themselves
-puts @feature_flags.feature_is_on? "MyFeature"  # returns yes 10 pct of the time
+result = client.enabled? "my-first-feature-flag", lookup_key, identity_attributes
 
-# A single user should get the same result each time
-puts @feature_flags.feature_is_on? "MyFeature", "user:1123"
+puts "my-first-feature-flag is: #{result} for #{lookup_key}"
 ```
-See full documentation https://www.prefab.cloud/documentation/installation
+See full documentation https://docs.prefab.cloud/docs/ruby-sdk/ruby
 
 ## Supports
 
@@ -74,5 +76,5 @@ REMOTE_BRANCH=main LOCAL_BRANCH=main bundle exec rake release
 
 ## Copyright
 
-Copyright (c) 2022 Jeff Dwyer. See LICENSE.txt for
+Copyright (c) 2023 Jeff Dwyer. See LICENSE.txt for
 further details.

--- a/lib/prefab/cancellable_interceptor.rb
+++ b/lib/prefab/cancellable_interceptor.rb
@@ -13,16 +13,16 @@ module Prefab
       i = 0
       while i < WAIT_SEC
         if @call.instance_variable_get('@wrapped').cancelled?
-          @base_client.log_internal Logger::DEBUG, 'Cancelled streaming.'
+          @base_client.log_internal ::Logger::DEBUG, 'Cancelled streaming.'
           return
         else
-          @base_client.log_internal Logger::DEBUG, 'Unable to cancel streaming. Trying again'
+          @base_client.log_internal ::Logger::DEBUG, 'Unable to cancel streaming. Trying again'
           @call.instance_variable_get('@wrapped').instance_variable_get('@call').cancel
           i += 1
           sleep(1)
         end
       end
-      @base_client.log_internal Logger::INFO, 'Unable to cancel streaming.'
+      @base_client.log_internal ::Logger::INFO, 'Unable to cancel streaming.'
     end
 
     def request_response(request:, call:, method:, metadata:, &block)

--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -10,7 +10,7 @@ module Prefab
     def initialize(base_client, timeout)
       @base_client = base_client
       @options = base_client.options
-      @base_client.log_internal Logger::DEBUG, 'Initialize ConfigClient'
+      @base_client.log_internal ::Logger::DEBUG, 'Initialize ConfigClient'
       @timeout = timeout
 
       @stream_lock = Concurrent::ReadWriteLock.new
@@ -21,9 +21,9 @@ module Prefab
       @config_resolver = Prefab::ConfigResolver.new(@base_client, @config_loader)
 
       @initialization_lock = Concurrent::ReadWriteLock.new
-      @base_client.log_internal Logger::DEBUG, 'Initialize ConfigClient: AcquireWriteLock'
+      @base_client.log_internal ::Logger::DEBUG, 'Initialize ConfigClient: AcquireWriteLock'
       @initialization_lock.acquire_write_lock
-      @base_client.log_internal Logger::DEBUG, 'Initialize ConfigClient: AcquiredWriteLock'
+      @base_client.log_internal ::Logger::DEBUG, 'Initialize ConfigClient: AcquiredWriteLock'
       @initialized_future = Concurrent::Future.execute { @initialization_lock.acquire_read_lock }
 
       @cancellable_interceptor = Prefab::CancellableInterceptor.new(@base_client)
@@ -99,7 +99,7 @@ module Prefab
           raise Prefab::Errors::InitializationTimeoutError.new(@options.initialization_timeout_sec, key)
         end
 
-        @base_client.log_internal Logger::WARN,
+        @base_client.log_internal ::Logger::WARN,
                                   "Couldn't Initialize In #{@options.initialization_timeout_sec}. Key #{key}. Returning what we have"
         @initialization_lock.release_write_lock
 
@@ -119,13 +119,13 @@ module Prefab
 
       return if success
 
-      @base_client.log_internal Logger::INFO, 'LoadCheckpoint: Fallback to GRPC API'
+      @base_client.log_internal ::Logger::INFO, 'LoadCheckpoint: Fallback to GRPC API'
 
       success = load_checkpoint_from_grpc_api
 
       return if success
 
-      @base_client.log_internal Logger::WARN, 'No success loading checkpoints'
+      @base_client.log_internal ::Logger::WARN, 'No success loading checkpoints'
     end
 
     def load_checkpoint_from_grpc_api
@@ -135,9 +135,9 @@ module Prefab
       load_configs(resp, :remote_api_grpc)
       true
     rescue GRPC::Unauthenticated
-      @base_client.log_internal Logger::WARN, 'Unauthenticated'
+      @base_client.log_internal ::Logger::WARN, 'Unauthenticated'
     rescue StandardError => e
-      @base_client.log_internal Logger::WARN, "Unexpected grpc_api problem loading checkpoint #{e}"
+      @base_client.log_internal ::Logger::WARN, "Unexpected grpc_api problem loading checkpoint #{e}"
       false
     end
 
@@ -162,11 +162,11 @@ module Prefab
         load_configs(configs, source)
         true
       else
-        @base_client.log_internal Logger::INFO, "Checkpoint #{source} failed to load. Response #{resp.status}"
+        @base_client.log_internal ::Logger::INFO, "Checkpoint #{source} failed to load. Response #{resp.status}"
         false
       end
     rescue StandardError => e
-      @base_client.log_internal Logger::WARN, "Unexpected #{source} problem loading checkpoint #{e} #{conn}"
+      @base_client.log_internal ::Logger::WARN, "Unexpected #{source} problem loading checkpoint #{e} #{conn}"
       false
     end
 
@@ -180,10 +180,10 @@ module Prefab
         @config_loader.set(config, source)
       end
       if @config_loader.highwater_mark > starting_highwater_mark
-        @base_client.log_internal Logger::INFO,
+        @base_client.log_internal ::Logger::INFO,
                                   "Found new checkpoint with highwater id #{@config_loader.highwater_mark} from #{source} in project #{project_id} environment: #{project_env_id} and namespace: '#{@namespace}'"
       else
-        @base_client.log_internal Logger::DEBUG,
+        @base_client.log_internal ::Logger::DEBUG,
                                   "Checkpoint with highwater id #{@config_loader.highwater_mark} from #{source}. No changes.", 'load_configs'
       end
       @base_client.stats.increment('prefab.config.checkpoint.load')
@@ -201,7 +201,7 @@ module Prefab
           delta = @checkpoint_freq_secs - (Time.now - started_at)
           sleep(delta) if delta > 0
         rescue StandardError => e
-          @base_client.log_internal Logger::INFO, "Issue Checkpointing #{e.message}"
+          @base_client.log_internal ::Logger::INFO, "Issue Checkpointing #{e.message}"
         end
       end
     end
@@ -209,10 +209,10 @@ module Prefab
     def finish_init!(source)
       return unless @initialization_lock.write_locked?
 
-      @base_client.log_internal Logger::INFO, "Unlocked Config via #{source}"
+      @base_client.log_internal ::Logger::INFO, "Unlocked Config via #{source}"
       @initialization_lock.release_write_lock
       @base_client.log.set_config_client(self)
-      @base_client.log_internal Logger::INFO, to_s
+      @base_client.log_internal ::Logger::INFO, to_s
     end
 
     def start_sse_streaming_connection_thread(start_at_id)
@@ -223,7 +223,7 @@ module Prefab
         "Authorization": "Basic #{auth_string}"
       }
       url = "#{@base_client.prefab_api_url}/api/v1/sse/config"
-      @base_client.log_internal Logger::INFO, "SSE Streaming Connect to #{url} start_at #{start_at_id}"
+      @base_client.log_internal ::Logger::INFO, "SSE Streaming Connect to #{url} start_at #{start_at_id}"
       @streaming_thread = SSE::Client.new(url,
                                           headers: headers,
                                           read_timeout: SSE_READ_TIMEOUT,

--- a/lib/prefab/config_loader.rb
+++ b/lib/prefab/config_loader.rb
@@ -29,7 +29,7 @@ module Prefab
         @api_config.delete(config.key)
       else
         if @api_config[config.key]
-          @base_client.log_internal Logger::DEBUG,
+          @base_client.log_internal ::Logger::DEBUG,
                                     "Replace #{config.key} with value from #{source} #{@api_config[config.key][:config].id} -> #{config.id}"
         end
         @api_config[config.key] = { source: source, config: config }

--- a/lib/prefab/internal_logger.rb
+++ b/lib/prefab/internal_logger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Prefab
-  class InternalLogger < Logger
+  class InternalLogger < ::Logger
     def initialize(path, logger)
       @path = path
       @logger = logger

--- a/lib/prefab/log_path_collector.rb
+++ b/lib/prefab/log_path_collector.rb
@@ -68,7 +68,8 @@ module Prefab
           loggers: aggregate.values,
           start_at: start_at_was,
           end_at: now,
-          instance_hash: @client.instance_hash
+          instance_hash: @client.instance_hash,
+          namespace: @client.namespace
         )
 
         @client.request Prefab::LoggerReportingService, :send, req_options: {}, params: loggers

--- a/lib/prefab/log_path_collector.rb
+++ b/lib/prefab/log_path_collector.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Prefab
+  class LogPathCollector
+    INCREMENT = ->(count) { (count || 0) + 1 }
+
+    SEVERITY_KEY = {
+      ::Logger::DEBUG => 'debugs',
+      ::Logger::INFO => 'infos',
+      ::Logger::WARN => 'warns',
+      ::Logger::ERROR => 'errors',
+      ::Logger::FATAL => 'fatals'
+    }.freeze
+
+    def initialize(client:, max_paths:, sync_interval:)
+      @max_paths = max_paths
+      @sync_interval = sync_interval
+      @client = client
+      @start_at = now
+
+      @pool = Concurrent::ThreadPoolExecutor.new(
+        fallback_policy: :discard,
+        max_queue: 5,
+        max_threads: 4,
+        min_threads: 1,
+        name: 'prefab-log-paths'
+      )
+
+      @paths = Concurrent::Map.new
+
+      start_periodic_sync
+    end
+
+    def push(path, severity)
+      return unless @paths.size < @max_paths
+
+      @paths.compute([path, severity], &INCREMENT)
+    end
+
+    private
+
+    def sync
+      return if @paths.size.zero?
+
+      log_internal "Syncing #{@paths.size} paths"
+
+      flush
+    end
+
+    def flush
+      to_ship = @paths.dup
+      @paths.clear
+
+      start_at_was = @start_at
+      @start_at = now
+
+      @pool.post do
+        log_internal "Uploading stats for #{to_ship.size} paths"
+
+        aggregate = Hash.new { |h, k| h[k] = Prefab::Logger.new }
+
+        to_ship.each do |(path, severity), count|
+          aggregate[path][SEVERITY_KEY[severity]] = count
+          aggregate[path]['logger_name'] = path
+        end
+
+        loggers = Prefab::Loggers.new(
+          loggers: aggregate.values,
+          start_at: start_at_was,
+          end_at: now,
+          instance_hash: @client.instance_hash
+        )
+
+        @client.request Prefab::LoggerReportingService, :send, req_options: {}, params: loggers
+      end
+    end
+
+    def start_periodic_sync
+      Thread.new do
+        log_internal "Initialized log path collector instance_hash=#{@client.instance_hash} max_paths=#{@max_paths} sync_interval=#{@sync_interval}"
+
+        loop do
+          sleep @sync_interval
+          sync
+        end
+      end
+    end
+
+    def log_internal(message)
+      @client.log.log_internal message, 'log_path_collector', nil, ::Logger::INFO
+    end
+
+    def now
+      (Time.now.utc.to_f * 1000).to_i
+    end
+  end
+end

--- a/lib/prefab/yaml_config_parser.rb
+++ b/lib/prefab/yaml_config_parser.rb
@@ -21,10 +21,10 @@ module Prefab
 
     def load
       if File.exist?(@file)
-        @client.log_internal Logger::INFO, "Load #{@file}"
+        @client.log_internal ::Logger::INFO, "Load #{@file}"
         YAML.load_file(@file)
       else
-        @client.log_internal Logger::INFO, "No file #{@file}"
+        @client.log_internal ::Logger::INFO, "No file #{@file}"
         {}
       end
     end

--- a/lib/prefab_pb.rb
+++ b/lib/prefab_pb.rb
@@ -181,6 +181,23 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :sequence_name, :string, 3
       optional :size, :int64, 4
     end
+    add_message "prefab.Loggers" do
+      repeated :loggers, :message, 1, "prefab.Logger"
+      optional :start_at, :int64, 2
+      optional :end_at, :int64, 3
+      optional :instance_hash, :string, 4
+    end
+    add_message "prefab.Logger" do
+      optional :logger_name, :string, 1
+      proto3_optional :traces, :int64, 2
+      proto3_optional :debugs, :int64, 3
+      proto3_optional :infos, :int64, 4
+      proto3_optional :warns, :int64, 5
+      proto3_optional :errors, :int64, 6
+      proto3_optional :fatals, :int64, 7
+    end
+    add_message "prefab.LoggerReportResponse" do
+    end
     add_enum "prefab.ConfigType" do
       value :NOT_SET_CONFIG_TYPE, 0
       value :CONFIG, 1
@@ -236,6 +253,9 @@ module Prefab
   CreationResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.CreationResponse").msgclass
   IdBlock = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.IdBlock").msgclass
   IdBlockRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.IdBlockRequest").msgclass
+  Loggers = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.Loggers").msgclass
+  Logger = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.Logger").msgclass
+  LoggerReportResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.LoggerReportResponse").msgclass
   ConfigType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.ConfigType").enummodule
   LogLevel = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.LogLevel").enummodule
   OnFailure = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("prefab.OnFailure").enummodule

--- a/lib/prefab_pb.rb
+++ b/lib/prefab_pb.rb
@@ -186,6 +186,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :start_at, :int64, 2
       optional :end_at, :int64, 3
       optional :instance_hash, :string, 4
+      proto3_optional :namespace, :string, 5
     end
     add_message "prefab.Logger" do
       optional :logger_name, :string, 1

--- a/lib/prefab_services_pb.rb
+++ b/lib/prefab_services_pb.rb
@@ -63,4 +63,18 @@ module Prefab
 
     Stub = Service.rpc_stub_class
   end
+  module LoggerReportingService
+    class Service
+
+      include ::GRPC::GenericService
+
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'prefab.LoggerReportingService'
+
+      rpc :Send, ::Prefab::Loggers, ::Prefab::LoggerReportResponse
+    end
+
+    Stub = Service.rpc_stub_class
+  end
 end

--- a/prefab-cloud-ruby.gemspec
+++ b/prefab-cloud-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Jeff Dwyer".freeze]
-  s.date = "2023-03-08"
+  s.date = "2023-03-13"
   s.description = "RateLimits & Config as a service".freeze
   s.email = "jdwyer@prefab.cloud".freeze
   s.extra_rdoc_files = [
@@ -75,7 +75,9 @@ Gem::Specification.new do |s|
     "test/test_helper.rb",
     "test/test_integration.rb",
     "test/test_local_config_parser.rb",
+    "test/test_log_path_collector.rb",
     "test/test_logger.rb",
+    "test/test_options.rb",
     "test/test_weighted_value_resolver.rb"
   ]
   s.homepage = "http://github.com/prefab-cloud/prefab-cloud-ruby".freeze

--- a/prefab-cloud-ruby.gemspec
+++ b/prefab-cloud-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Jeff Dwyer".freeze]
-  s.date = "2023-02-27"
+  s.date = "2023-03-08"
   s.description = "RateLimits & Config as a service".freeze
   s.email = "jdwyer@prefab.cloud".freeze
   s.extra_rdoc_files = [
@@ -48,6 +48,7 @@ Gem::Specification.new do |s|
     "lib/prefab/feature_flag_client.rb",
     "lib/prefab/internal_logger.rb",
     "lib/prefab/local_config_parser.rb",
+    "lib/prefab/log_path_collector.rb",
     "lib/prefab/logger_client.rb",
     "lib/prefab/murmer3.rb",
     "lib/prefab/noop_cache.rb",
@@ -93,6 +94,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency(%q<google-protobuf>.freeze, [">= 0"])
     s.add_runtime_dependency(%q<grpc>.freeze, [">= 0"])
     s.add_runtime_dependency(%q<ld-eventsource>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<uuid>.freeze, [">= 0"])
     s.add_development_dependency(%q<benchmark-ips>.freeze, [">= 0"])
     s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_development_dependency(%q<grpc-tools>.freeze, [">= 0"])
@@ -106,6 +108,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<google-protobuf>.freeze, [">= 0"])
     s.add_dependency(%q<grpc>.freeze, [">= 0"])
     s.add_dependency(%q<ld-eventsource>.freeze, [">= 0"])
+    s.add_dependency(%q<uuid>.freeze, [">= 0"])
     s.add_dependency(%q<benchmark-ips>.freeze, [">= 0"])
     s.add_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_dependency(%q<grpc-tools>.freeze, [">= 0"])

--- a/test/test_log_path_collector.rb
+++ b/test/test_log_path_collector.rb
@@ -11,34 +11,32 @@ class TestLogPathCollector < Minitest::Test
       2.times { client.log.info('here is a message') }
       3.times { client.log.error('here is a message') }
 
-      mock_request = Minitest::Mock.new
-
-      mock_request.expect(:request, :return_value_we_do_not_care_about, [
-                            Prefab::LoggerReportingService,
-                            :send,
-                            {
-                              req_options: {},
-                              params: Prefab::Loggers.new(
-                                loggers: [Prefab::Logger.new(logger_name: 'test.test_log_path_collector.test_sync',
-                                                             infos: 2, errors: 3)],
-                                start_at: (Time.now.utc.to_f * 1000).to_i,
-                                end_at: (Time.now.utc.to_f * 1000).to_i,
-                                instance_hash: client.instance_hash,
-                                namespace: 'this.is.a.namespace'
-                              )
-                            }
-                          ])
+      requests = []
 
       client.define_singleton_method(:request) do |*params|
-        mock_request.request(*params)
+        requests.push(params)
       end
 
       client.log_path_collector.send(:sync)
 
       # let the flush thread run
-      sleep 0.01 while mock_request.instance_eval { @actual_calls }.size.zero?
+      sleep 0.01 while requests.length == 0
 
-      mock_request.verify
+      assert_equal requests, [[
+        Prefab::LoggerReportingService,
+        :send,
+        {
+          req_options: {},
+          params: Prefab::Loggers.new(
+            loggers: [Prefab::Logger.new(logger_name: 'test.test_log_path_collector.test_sync',
+                                         infos: 2, errors: 3)],
+            start_at: (Time.now.utc.to_f * 1000).to_i,
+            end_at: (Time.now.utc.to_f * 1000).to_i,
+            instance_hash: client.instance_hash,
+            namespace: 'this.is.a.namespace'
+          )
+        }
+      ]]
     end
   end
 

--- a/test/test_log_path_collector.rb
+++ b/test/test_log_path_collector.rb
@@ -49,6 +49,7 @@ class TestLogPathCollector < Minitest::Test
       prefab_config_override_dir: 'none',
       prefab_config_classpath_dir: 'test',
       prefab_envs: ['unit_tests'],
+      api_key: '123-development-yourapikey-SDK',
       collect_sync_interval: 1000 # we'll trigger sync manually in our test
     }.merge(overrides))
 

--- a/test/test_log_path_collector.rb
+++ b/test/test_log_path_collector.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'timecop'
+
+class TestLogPathCollector < Minitest::Test
+  def test_sync
+    Timecop.freeze do
+      client = new_client(namespace: 'this.is.a.namespace')
+
+      2.times { client.log.info('here is a message') }
+      3.times { client.log.error('here is a message') }
+
+      mock_request = Minitest::Mock.new
+
+      mock_request.expect(:request, :return_value_we_do_not_care_about, [
+                            Prefab::LoggerReportingService,
+                            :send,
+                            {
+                              req_options: {},
+                              params: Prefab::Loggers.new(
+                                loggers: [Prefab::Logger.new(logger_name: 'test.test_log_path_collector.test_sync',
+                                                             infos: 2, errors: 3)],
+                                start_at: (Time.now.utc.to_f * 1000).to_i,
+                                end_at: (Time.now.utc.to_f * 1000).to_i,
+                                instance_hash: client.instance_hash,
+                                namespace: 'this.is.a.namespace'
+                              )
+                            }
+                          ])
+
+      client.define_singleton_method(:request) do |*params|
+        mock_request.request(*params)
+      end
+
+      client.log_path_collector.send(:sync)
+
+      # let the flush thread run
+      sleep 0.01 while mock_request.instance_eval { @actual_calls }.size.zero?
+
+      mock_request.verify
+    end
+  end
+
+  private
+
+  def new_client(overrides = {})
+    options = Prefab::Options.new(**{
+      prefab_config_override_dir: 'none',
+      prefab_config_classpath_dir: 'test',
+      prefab_envs: ['unit_tests'],
+      collect_sync_interval: 1000 # we'll trigger sync manually in our test
+    }.merge(overrides))
+
+    Prefab::Client.new(options)
+  end
+end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -47,37 +47,37 @@ class TestCLogger < Minitest::Test
   def test_level_of
     with_env('PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL', 'info') do
       # env var overrides the default level
-      assert_equal Logger::INFO,
+      assert_equal ::Logger::INFO,
                    @logger.level_of('app.models.user'), 'PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL is info'
 
       @logger.set_config_client(MockConfigClient.new({}))
-      assert_equal Logger::WARN,
+      assert_equal ::Logger::WARN,
                    @logger.level_of('app.models.user'), 'default is warn'
 
       @logger.set_config_client(MockConfigClient.new('log-level.app' => :INFO))
-      assert_equal Logger::INFO,
+      assert_equal ::Logger::INFO,
                    @logger.level_of('app.models.user')
 
       @logger.set_config_client(MockConfigClient.new('log-level.app' => :DEBUG))
-      assert_equal Logger::DEBUG,
+      assert_equal ::Logger::DEBUG,
                    @logger.level_of('app.models.user')
 
       @logger.set_config_client(MockConfigClient.new('log-level.app' => :DEBUG,
                                                      'log-level.app.models' => :ERROR))
-      assert_equal Logger::ERROR,
+      assert_equal ::Logger::ERROR,
                    @logger.level_of('app.models.user'), 'test leveling'
     end
   end
 
   def test_log_internal
     logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- cloud.prefab.client.test.path: : test message/)
-    logger.log_internal('test message', 'test.path', '', Logger::WARN)
+    logger.log_internal('test message', 'test.path', '', ::Logger::WARN)
     mock_logdev.verify
   end
 
   def test_log_internal_unknown
     logger, mock_logdev = mock_logger_expecting(/A, \[.*\]   ANY -- cloud.prefab.client.test.path: : test message/)
-    logger.log_internal('test message', 'test.path', '', Logger::UNKNOWN)
+    logger.log_internal('test message', 'test.path', '', ::Logger::UNKNOWN)
     mock_logdev.verify
   end
 
@@ -85,30 +85,30 @@ class TestCLogger < Minitest::Test
     logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- cloud.prefab.client.test.path: : should log/,
                                                 calls: 2)
     logger.silence do
-      logger.log_internal('should not log', 'test.path', '', Logger::WARN)
+      logger.log_internal('should not log', 'test.path', '', ::Logger::WARN)
     end
-    logger.log_internal('should log', 'test.path', '', Logger::WARN)
+    logger.log_internal('should log', 'test.path', '', ::Logger::WARN)
     mock_logdev.verify
   end
 
   def test_log
     logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : test message/)
-    logger.log('test message', 'test.path', '', Logger::WARN)
+    logger.log('test message', 'test.path', '', ::Logger::WARN)
     mock_logdev.verify
   end
 
   def test_log_unknown
     logger, mock_logdev = mock_logger_expecting(/A, \[.*\]   ANY -- test.path: : test message/)
-    logger.log('test message', 'test.path', '', Logger::UNKNOWN)
+    logger.log('test message', 'test.path', '', ::Logger::UNKNOWN)
     mock_logdev.verify
   end
 
   def test_log_silencing
     logger, mock_logdev = mock_logger_expecting(/W, \[.*\]  WARN -- test.path: : should log/, calls: 2)
     logger.silence do
-      logger.log('should not log', 'test.path', '', Logger::WARN)
+      logger.log('should not log', 'test.path', '', ::Logger::WARN)
     end
-    logger.log('should log', 'test.path', '', Logger::WARN)
+    logger.log('should log', 'test.path', '', ::Logger::WARN)
     mock_logdev.verify
   end
 

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -12,4 +12,21 @@ class TestOptions < Minitest::Test
   def test_works_with_hash
     assert_equal API_KEY, Prefab::Options.new({ api_key: API_KEY }).api_key
   end
+
+  def test_collect_max_paths
+    assert_equal 1000, Prefab::Options.new.collect_max_paths
+    assert_equal 100, Prefab::Options.new(collect_max_paths: 100).collect_max_paths
+  end
+
+  def test_collect_max_paths_with_local_only
+    options = Prefab::Options.new(collect_max_paths: 100,
+                                  prefab_datasources: Prefab::Options::DATASOURCES::LOCAL_ONLY)
+    assert_equal 0, options.collect_max_paths
+  end
+
+  def test_collect_max_paths_with_collect_logs_false
+    options = Prefab::Options.new(collect_max_paths: 100,
+                                  collect_logs: false)
+    assert_equal 0, options.collect_max_paths
+  end
 end


### PR DESCRIPTION
You can opt-out via `collect_logs: false` in options or by using
local-only data sources.

Note that since we've introduced `Prefab::Logger` in the proto that we
had to prefix `Logger` with `::` in many cases so we're properly
referring to the top-level constant.
