### PR TITLE
set rails loggers

### DIFF
--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -82,6 +82,15 @@ module Prefab
                                                                    log_path_collector: log_path_collector)
     end
 
+    def set_rails_loggers
+      Rails.logger = log
+      ActionView::Base.logger = log
+      ActionController::Base.logger = log
+      ActiveJob::Base.logger = log
+      ActiveRecord::Base.logger = log
+      ActiveStorage.logger = log
+    end
+
     def log_internal(level, msg, path = nil)
       log.log_internal msg, path, nil, level
     end


### PR DESCRIPTION
Rails.logger works for most things and non-forking servers.

With forking servers like Puma/Unicorn however, classes like `ActionView::LogSubscriber` which are set to `ActionView::Base.logger` end up with an outdated reference post fork.

Set these loggers explicitly.