### PR TITLE
Fix: Handle trailing slash in PREFAB_API_URL

### DIFF
--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -71,7 +71,7 @@ module Prefab
       @namespace = namespace
       @log_formatter = log_formatter
       @log_prefix = log_prefix
-      @prefab_api_url = prefab_api_url
+      @prefab_api_url = remove_trailing_slash(prefab_api_url)
       @prefab_grpc_url = prefab_grpc_url
       @on_no_default = on_no_default
       @initialization_timeout_sec = initialization_timeout_sec
@@ -102,6 +102,12 @@ module Prefab
     # https://api.prefab.cloud -> https://api-prefab-cloud.global.ssl.fastly.net
     def url_for_api_cdn
       ENV['PREFAB_CDN_URL'] || "#{@prefab_api_url.gsub(/\./, '-')}.global.ssl.fastly.net"
+    end
+
+    private
+
+    def remove_trailing_slash(url)
+      url.end_with?('/') ? url[0..-2] : url
     end
   end
 end

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -5,6 +5,18 @@ require 'test_helper'
 class TestOptions < Minitest::Test
   API_KEY = 'abcdefg'
 
+  def test_prefab_api_url
+    assert_equal 'https://api.prefab.cloud', Prefab::Options.new.prefab_api_url
+
+    with_env 'PREFAB_API_URL', 'https://api.prefab.cloud' do
+      assert_equal 'https://api.prefab.cloud', Prefab::Options.new.prefab_api_url
+    end
+
+    with_env 'PREFAB_API_URL', 'https://api.prefab.cloud/' do
+      assert_equal 'https://api.prefab.cloud', Prefab::Options.new.prefab_api_url
+    end
+  end
+
   def test_works_with_named_arguments
     assert_equal API_KEY, Prefab::Options.new(api_key: API_KEY).api_key
   end


### PR DESCRIPTION
Having a trailing slash here can lead to double slashes when we assemble
urls later.
