### PR TITLE
Cast the value to string when checking presence in string list

### DIFF
--- a/lib/prefab/criteria_evaluator.rb
+++ b/lib/prefab/criteria_evaluator.rb
@@ -87,7 +87,9 @@ module Prefab
 
       case criterion_value_or_values
       when Google::Protobuf::RepeatedField
-        criterion_value_or_values.include?(value_from_properties)
+        # we to_s the value from properties for comparison because the
+        # criterion_value_or_values is a list of strings
+        criterion_value_or_values.include?(value_from_properties.to_s)
       else
         criterion_value_or_values == value_from_properties
       end


### PR DESCRIPTION
Since lists are stored as strings, non-string values provided by the
user here would never match.
