### PR TITLE
Backwards compatability for JIT context

### DIFF
--- a/test/.prefab.unit_tests.config.yaml
+++ b/test/.prefab.unit_tests.config.yaml
@@ -11,6 +11,7 @@ disabled_flag: false
 flag_with_a_value: { "feature_flag": "true", value: "all-features" }
 user_key_match: { "feature_flag": "true", value: true, criterion: { operator: PROP_IS_ONE_OF, values: [ "abc123", "xyz987" ], property: "user.key" } }
 just_my_domain: { "feature_flag": "true", value: "new-version", criterion: { operator: PROP_IS_ONE_OF, property: "user.domain", values: [ "prefab.cloud", "example.com" ] } }
+deprecated_no_dot_notation: { "feature_flag": "true", value: true, criterion: { operator: PROP_IS_ONE_OF, property: "domain", values: [ "prefab.cloud", "example.com" ] } }
 
 nested:
   values:

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -50,18 +50,30 @@ class TestClient < Minitest::Test
     assert_equal_context_and_jit(true, :enabled?, 'user_key_match', { user: { key: 'xyz987' } })
   end
 
-  def test_ff_enabled_with_attributes
+  def test_ff_enabled_with_context
     assert_equal_context_and_jit(false, :enabled?, 'just_my_domain', user: { domain: 'gmail.com' })
     assert_equal_context_and_jit(false, :enabled?, 'just_my_domain', user: { domain: 'prefab.cloud' })
     assert_equal_context_and_jit(false, :enabled?, 'just_my_domain', user: { domain: 'example.com' })
   end
 
-  def test_ff_get_with_attributes
+  def test_ff_get_with_context
     assert_nil @client.get('just_my_domain', 'abc123', user: { domain: 'gmail.com' })
     assert_equal 'DEFAULT', @client.get('just_my_domain', 'abc123', { user: { domain: 'gmail.com' } }, 'DEFAULT')
 
     assert_equal_context_and_jit('new-version', :get, 'just_my_domain', { user: { domain: 'prefab.cloud' } })
     assert_equal_context_and_jit('new-version', :get, 'just_my_domain', { user: { domain: 'example.com' } })
+  end
+
+  def test_deprecated_no_dot_notation_ff_enabled_with_jit_context
+    # with no lookup key
+    assert_equal false, @client.enabled?('deprecated_no_dot_notation', { domain: 'gmail.com' })
+    assert_equal true, @client.enabled?('deprecated_no_dot_notation', { domain: 'prefab.cloud' })
+    assert_equal true, @client.enabled?('deprecated_no_dot_notation', { domain: 'example.com' })
+
+    # with a lookup key
+    assert_equal false, @client.enabled?('deprecated_no_dot_notation', 'some-lookup-key', { domain: 'gmail.com' })
+    assert_equal true, @client.enabled?('deprecated_no_dot_notation', 'some-lookup-key', { domain: 'prefab.cloud' })
+    assert_equal true, @client.enabled?('deprecated_no_dot_notation', 'some-lookup-key', { domain: 'example.com' })
   end
 
   def test_getting_feature_flag_value

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -35,9 +35,12 @@ class TestContext < Minitest::Test
   end
 
   def test_initialize_with_invalid_hash
-    assert_raises(ArgumentError) do
+    _, err = capture_io do
       Prefab::Context.new({ foo: 'bar', baz: 'qux' })
     end
+
+    assert_match '[DEPRECATION] Prefab contexts should be a hash with a key of the context name and a value of a hash',
+                 err
   end
 
   def test_initialize_with_invalid_argument


### PR DESCRIPTION
Support nameless context.

e.g.

```ruby
$prefab.enabled?("my-first-feature-flag", "lookup_key", { subscription_level: 'pro' })
```

Would let you check the property name `subscription_level` without any
parent (no dot notation)
