### PR TITLE
Fix misleading deprecation warning

### DIFF
--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -90,12 +90,12 @@ module Prefab
     end
 
     def get(key, default_or_lookup_key = NO_DEFAULT_PROVIDED, properties = NO_DEFAULT_PROVIDED, ff_default = nil)
-      default, properties = handle_positional_arguments(default_or_lookup_key, properties, :get)
-
       if is_ff?(key)
+        default, properties = handle_positional_arguments(default_or_lookup_key, properties, :get)
+
         feature_flag_client.get(key, properties, default: ff_default)
       else
-        config_client.get(key, default, properties)
+        config_client.get(key, default_or_lookup_key, properties)
       end
     end
 
@@ -134,7 +134,7 @@ module Prefab
       end
 
       if lookup_key.is_a?(String)
-        warn "[DEPRECATION] `$prefab.#{method}`'s lookup_key argument is deprecated. Please use remove it or use context instead."
+        warn "[DEPRECATION] `$prefab.#{method}`'s lookup_key argument is deprecated. Please remove it or use context instead."
       end
 
       [lookup_key, properties]

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -8,8 +8,12 @@ class TestClient < Minitest::Test
   end
 
   def test_get
-    assert_equal 'test sample value', @client.get('sample')
-    assert_equal 123, @client.get('sample_int')
+    _, err = capture_io do
+      assert_equal 'default', @client.get('does.not.exist', 'default')
+      assert_equal 'test sample value', @client.get('sample')
+      assert_equal 123, @client.get('sample_int')
+    end
+    assert_equal '', err
   end
 
   def test_get_with_default


### PR DESCRIPTION
The lookup_key deprecation showed up when a default string was provided
for a config.
