### PR TITLE
easily choose a JSON logger

### DIFF
--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -174,7 +174,7 @@ module Prefab
     def format_message(severity, datetime, progname, msg, path)
       formatter = (@formatter || @default_formatter)
 
-      if formatter.method(:call).arity == 5
+      if formatter.arity == 5
         formatter.call(severity, datetime, progname, msg, path)
       else
         formatter.call(severity, datetime, join_path_and_progname(path, progname), msg)

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -21,6 +21,14 @@ module Prefab
     DEFAULT_LOG_FORMATTER = proc { |severity, datetime, progname, msg|
       "#{severity.ljust(5)} #{datetime}:#{' ' if progname}#{progname} #{msg}\n"
     }
+    JSON_LOG_FORMATTER = proc { |severity, datetime, progname, msg|
+      {
+        type: severity,
+        time: datetime,
+        logger: progname,
+        message: msg
+      }.to_json << "\n"
+    }
 
     module ON_INITIALIZATION_FAILURE
       RAISE = 1

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -21,13 +21,14 @@ module Prefab
     DEFAULT_LOG_FORMATTER = proc { |severity, datetime, progname, msg|
       "#{severity.ljust(5)} #{datetime}:#{' ' if progname}#{progname} #{msg}\n"
     }
-    JSON_LOG_FORMATTER = proc { |severity, datetime, progname, msg|
+    JSON_LOG_FORMATTER = proc { |severity, datetime, progname, msg, path|
       {
         type: severity,
         time: datetime,
-        logger: progname,
-        message: msg
-      }.to_json << "\n"
+        progname: progname,
+        message: msg,
+        path: path
+      }.compact.to_json << "\n"
     }
 
     module ON_INITIALIZATION_FAILURE


### PR DESCRIPTION
This outputs
```json
{"type":"INFO","time":"2023-05-09T14:07:07.591-04:00","logger":"cloud.prefab.client: ","message":"SSE Streaming Connect"}
```
This is pretty close, but, it seems like the `: ` formatting shouldn't really be in the JSON field.

That `:` works ok in the case of a sentry line which appears as:
```json
{"type":"DEBUG","time":"2023-05-09T14:07:07.935-04:00","logger":"sentry.utils.logging_helper.log_debug: sentry","message":"initialized a background worker with 10 threads"}
```
I believe that must be `progname` at work? 


For context, the text-only log lines are:
```bash
WARN  2023-05-09 12:05:20 -0400: app.controllers.prefab_controller.index: warn level
```
We're a bit inconsistent on `:` usage there. 

Open to suggestions here. Maybe best to just remove all the `:`? The interplay of `msg` and `progname` is a bit confusing to me.