### PR TITLE
helper for simpler on_worker_boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $prefab.set_rails_loggers
 ```ruby
 #puma.rb
 on_worker_boot do
-  $prefab = Prefab::Client.new
+  $prefab = $prefab.fork
   $prefab.set_rails_loggers
 end
 ```
@@ -49,7 +49,7 @@ end
 ```ruby
 # unicorn.rb
 after_fork do |server, worker|
-  $prefab = Prefab::Client.new(options)
+  $prefab = $prefab.fork
   $prefab.set_rails_loggers
 end
 ```

--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -111,6 +111,15 @@ module Prefab
       config_client.resolver
     end
 
+    # When starting a forked process, use this to re-use the options
+    # on_worker_boot do
+    #   $prefab = $prefab.fork
+    #   $prefab.set_rails_loggers
+    # end
+    def fork
+      Prefab::Client.new(@options)
+    end
+
     private
 
     def is_ff?(key)


### PR DESCRIPTION
If I am using `Prefab::Options` to setup the client in `application.rb` but also using puma or a forking server, it's a bit awkward to know where to put the options so I can re-use the same ones. 

This is a simple helper so that the following works: 

```ruby
on_worker_boot do
  $prefab = $prefab.fork
  $prefab.set_rails_loggers
end
```

Open to suggestions on a better name or approach here.