### PR TITLE
Fix bug in FF rollout eval consistency

### DIFF
--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -55,10 +55,11 @@ module Prefab
     end
 
     def get(key, default = NO_DEFAULT_PROVIDED, properties = NO_DEFAULT_PROVIDED)
-      value = _get(key, properties)
+      context = @config_resolver.make_context(properties)
+      value = _get(key, context)
 
       if value
-        Prefab::ConfigValueUnwrapper.unwrap(value, key, properties)
+        Prefab::ConfigValueUnwrapper.unwrap(value, key, context)
       else
         handle_default(key, default)
       end

--- a/lib/prefab/config_resolver.rb
+++ b/lib/prefab/config_resolver.rb
@@ -42,7 +42,7 @@ module Prefab
                                     project_env_id: @project_env_id,
                                     resolver: self,
                                     namespace: @base_client.options.namespace,
-                                    base_client: @base_client).evaluate(context(properties))
+                                    base_client: @base_client).evaluate(make_context(properties))
     end
 
     def update
@@ -55,9 +55,7 @@ module Prefab
       @on_update = block
     end
 
-    private
-
-    def context(properties)
+    def make_context(properties)
       if properties == NO_DEFAULT_PROVIDED
         Context.current
       elsif properties.is_a?(Context)
@@ -66,6 +64,8 @@ module Prefab
         Context.merge_with_current(properties)
       end
     end
+
+    private
 
     def make_local
       @lock.with_write_lock do

--- a/lib/prefab/config_value_unwrapper.rb
+++ b/lib/prefab/config_value_unwrapper.rb
@@ -14,7 +14,7 @@ module Prefab
         value = Prefab::WeightedValueResolver.new(
           config_value.weighted_values.weighted_values,
           config_key,
-          context[config_value.weighted_values.hash_by_property_name]
+          context.get(config_value.weighted_values.hash_by_property_name)
         ).resolve
 
         unwrap(value.value, config_key, context)

--- a/lib/prefab/context.rb
+++ b/lib/prefab/context.rb
@@ -77,16 +77,8 @@ module Prefab
       end
     end
 
-    def merge!(name, hash)
-      @contexts[name.to_s] = context(name).merge!(hash)
-    end
-
     def set(name, hash)
       @contexts[name.to_s] = NamedContext.new(name, hash)
-    end
-
-    def []=(name, hash)
-      set(name, hash)
     end
 
     def get(property_key)
@@ -98,10 +90,6 @@ module Prefab
       end
 
       contexts[name] && contexts[name].get(key)
-    end
-
-    def [](property_key)
-      get(property_key)
     end
 
     def to_h

--- a/lib/prefab/resolved_config_presenter.rb
+++ b/lib/prefab/resolved_config_presenter.rb
@@ -45,7 +45,7 @@ module Prefab
               hash[k] = ConfigRow.new(k, nil, nil, nil)
             else
               config = @resolver.evaluate(v[:config])
-              value = Prefab::ConfigValueUnwrapper.unwrap(config, k, {})
+              value = Prefab::ConfigValueUnwrapper.unwrap(config, k, Prefab::Context.new)
               hash[k] = ConfigRow.new(k, value, v[:match], v[:source])
             end
           end
@@ -67,7 +67,7 @@ module Prefab
               elements << 'tombstone'
             else
               config = @resolver.evaluate(v[:config], {})
-              value = Prefab::ConfigValueUnwrapper.unwrap(config, k, {})
+              value = Prefab::ConfigValueUnwrapper.unwrap(config, k, Prefab::Context.new)
               elements << value.to_s.slice(0..34).ljust(35)
               elements << value.class.to_s.slice(0..6).ljust(7)
               elements << "Match: #{v[:match]}".slice(0..29).ljust(30)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -12,7 +12,9 @@ class IntegrationTest
   end
 
   def test_type
-    if @expected[:status] == 'raise'
+    if @input[0] && @input[0].start_with?('log-level.')
+      :log_level
+    elsif @expected[:status] == 'raise'
       :raise
     elsif @expected[:value].nil?
       :nil

--- a/test/test_config_value_unwrapper.rb
+++ b/test/test_config_value_unwrapper.rb
@@ -4,45 +4,46 @@ require 'test_helper'
 
 class TestConfigValueUnwrapper < Minitest::Test
   CONFIG_KEY = 'config_key'
+  EMPTY_CONTEXT = Prefab::Context.new()
 
   def test_unwrapping_int
     config_value = Prefab::ConfigValue.new(int: 123)
-    assert_equal 123, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal 123, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
   end
 
   def test_unwrapping_string
     config_value = Prefab::ConfigValue.new(string: 'abc')
-    assert_equal 'abc', Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal 'abc', Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
   end
 
   def test_unwrapping_double
     config_value = Prefab::ConfigValue.new(double: 1.23)
-    assert_equal 1.23, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal 1.23, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
   end
 
   def test_unwrapping_bool
     config_value = Prefab::ConfigValue.new(bool: true)
-    assert_equal true, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal true, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
 
     config_value = Prefab::ConfigValue.new(bool: false)
-    assert_equal false, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal false, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
   end
 
   def test_unwrapping_log_level
     config_value = Prefab::ConfigValue.new(log_level: :INFO)
-    assert_equal :INFO, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal :INFO, Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
   end
 
   def test_unwrapping_string_list
     config_value = Prefab::ConfigValue.new(string_list: Prefab::StringList.new(values: %w[a b c]))
-    assert_equal %w[a b c], Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal %w[a b c], Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
   end
 
   def test_unwrapping_weighted_values
     # single value
     config_value = Prefab::ConfigValue.new(weighted_values: weighted_values([['abc', 1]]))
 
-    assert_equal 'abc', Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, {})
+    assert_equal 'abc', Prefab::ConfigValueUnwrapper.unwrap(config_value, CONFIG_KEY, EMPTY_CONTEXT)
 
     # multiple values, evenly distributed
     config_value = Prefab::ConfigValue.new(weighted_values: weighted_values([['abc', 1], ['def', 1], ['ghi', 1]]))

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -86,7 +86,7 @@ class TestContext < Minitest::Test
     Prefab::Context.with_context(EXAMPLE_PROPERTIES) do
       context = Prefab::Context.current
       assert_equal(stringify(EXAMPLE_PROPERTIES), context.to_h)
-      assert_equal('some-user-key', context['user.key'])
+      assert_equal('some-user-key', context.get('user.key'))
     end
   end
 
@@ -105,34 +105,24 @@ class TestContext < Minitest::Test
   def test_setting
     context = Prefab::Context.new({})
     context.set('user', { key: 'value' })
-    context[:other] = { key: 'different', something: 'other' }
+    context.set(:other, { key: 'different', something: 'other' })
     assert_equal(stringify({ user: { key: 'value' }, other: { key: 'different', something: 'other' } }), context.to_h)
   end
 
   def test_getting
     context = Prefab::Context.new(EXAMPLE_PROPERTIES)
     assert_equal('some-user-key', context.get('user.key'))
-    assert_equal('some-user-key', context['user.key'])
     assert_equal('pro', context.get('team.plan'))
-    assert_equal('pro', context['team.plan'])
   end
 
   def test_dot_notation_getting
     context = Prefab::Context.new({ 'user' => { 'key' => 'value' } })
     assert_equal('value', context.get('user.key'))
-    assert_equal('value', context['user.key'])
   end
 
   def test_dot_notation_getting_with_symbols
     context = Prefab::Context.new({ user: { key: 'value' } })
     assert_equal('value', context.get('user.key'))
-    assert_equal('value', context['user.key'])
-  end
-
-  def test_merge
-    context = Prefab::Context.new(EXAMPLE_PROPERTIES)
-    context.merge!(:other, { key: 'different' })
-    assert_equal(stringify(EXAMPLE_PROPERTIES.merge(other: { key: 'different' })), context.to_h)
   end
 
   def test_clear

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -13,7 +13,7 @@ class TestIntegration < Minitest::Test
       parent_context = test['context']
 
       test['cases'].each do |test_case|
-        define_method(:"test_#{test_case['name']}") do
+        define_method(:"test_#{test['name']}_#{test_case['name']}") do
           it = IntegrationTest.new(test_case)
 
           with_parent_context_maybe(parent_context) do
@@ -30,6 +30,10 @@ class TestIntegration < Minitest::Test
               assert_equal it.expected[:value], it.test_client.send(it.func, flag, context)
             when :simple_equality
               assert_equal it.expected[:value], it.test_client.send(it.func, *it.input)
+            when :log_level
+              assert_equal it.expected[:value].to_sym, it.test_client.send(it.func, *it.input)
+            else
+              raise "Unknown test type: #{it.test_type}"
             end
           end
         end


### PR DESCRIPTION
- The context wasn't being properly converted here so the lookup could
fail.
- Make `Context` behave less like a hash (to prevent accidentally using
them interchangeably).
- Use new version of integration test
- Prevent test name collisions in the integration test by using `name`s
  from top-level and case-level.
