### PR TITLE
`LoggerClient#add` -> `LoggerClient#add_internal`

### DIFF
--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -182,7 +182,7 @@ module Prefab
 
       @base_client.log_internal ::Logger::INFO, "Unlocked Config via #{source}"
       @initialization_lock.release_write_lock
-      @base_client.log.set_config_client(self)
+      @base_client.log.config_client = self
       @base_client.log_internal ::Logger::INFO, to_s
     end
 

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -65,20 +65,20 @@ class TestLogger < Minitest::Test
       assert_equal ::Logger::INFO,
                    @logger.level_of('app.models.user'), 'PREFAB_LOG_CLIENT_BOOTSTRAP_LOG_LEVEL is info'
 
-      @logger.set_config_client(MockConfigClient.new({}))
+      @logger.config_client = MockConfigClient.new({})
       assert_equal ::Logger::WARN,
                    @logger.level_of('app.models.user'), 'default is warn'
 
-      @logger.set_config_client(MockConfigClient.new('log-level.app' => :INFO))
+      @logger.config_client = MockConfigClient.new('log-level.app' => :INFO)
       assert_equal ::Logger::INFO,
                    @logger.level_of('app.models.user')
 
-      @logger.set_config_client(MockConfigClient.new('log-level.app' => :DEBUG))
+      @logger.config_client = MockConfigClient.new('log-level.app' => :DEBUG)
       assert_equal ::Logger::DEBUG,
                    @logger.level_of('app.models.user')
 
-      @logger.set_config_client(MockConfigClient.new('log-level.app' => :DEBUG,
-                                                     'log-level.app.models' => :ERROR))
+      @logger.config_client = MockConfigClient.new('log-level.app' => :DEBUG,
+                                                   'log-level.app.models' => :ERROR)
       assert_equal ::Logger::ERROR,
                    @logger.level_of('app.models.user'), 'test leveling'
     end


### PR DESCRIPTION
This should prevent conflicts with libraries that use `add` directly (e.g. honeybadger)

Similarly we change `format_message` to conform to the default Ruby logger signature by making the last param default to nil.
