### PR TITLE
Remove backwards-compatibility shims for `.get` and `.enabled?`

### DIFF
--- a/lib/prefab/config_resolver.rb
+++ b/lib/prefab/config_resolver.rb
@@ -54,7 +54,7 @@ module Prefab
     end
 
     def make_context(properties)
-      if properties == NO_DEFAULT_PROVIDED
+      if properties == NO_DEFAULT_PROVIDED || properties.nil?
         Context.current
       elsif properties.is_a?(Context)
         properties

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -18,8 +18,6 @@ class IntegrationTest
       :raise
     elsif @expected[:value].nil?
       :nil
-    elsif @func == :feature_is_on_for?
-      :feature_flag
     else
       :simple_equality
     end
@@ -60,7 +58,7 @@ class IntegrationTest
   end
 
   def parse_ff_input(input)
-    [input['flag'], input['context']]
+    [input['flag'], input['default'], input['context']]
   end
 
   def parse_expected(expected)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -82,8 +82,7 @@ class TestClient < Minitest::Test
   end
 
   def test_ff_get_with_context
-    assert_nil @client.get('just_my_domain', 'abc123', user: { domain: 'gmail.com' })
-    assert_equal 'DEFAULT', @client.get('just_my_domain', 'abc123', { user: { domain: 'gmail.com' } }, 'DEFAULT')
+    assert_equal 'DEFAULT', @client.get('just_my_domain', 'DEFAULT', { user: { domain: 'gmail.com' } })
 
     assert_equal_context_and_jit('new-version', :get, 'just_my_domain', { user: { domain: 'prefab.cloud' } })
     assert_equal_context_and_jit('new-version', :get, 'just_my_domain', { user: { domain: 'example.com' } })
@@ -94,11 +93,6 @@ class TestClient < Minitest::Test
     assert_equal false, @client.enabled?('deprecated_no_dot_notation', { domain: 'gmail.com' })
     assert_equal true, @client.enabled?('deprecated_no_dot_notation', { domain: 'prefab.cloud' })
     assert_equal true, @client.enabled?('deprecated_no_dot_notation', { domain: 'example.com' })
-
-    # with a lookup key
-    assert_equal false, @client.enabled?('deprecated_no_dot_notation', 'some-lookup-key', { domain: 'gmail.com' })
-    assert_equal true, @client.enabled?('deprecated_no_dot_notation', 'some-lookup-key', { domain: 'prefab.cloud' })
-    assert_equal true, @client.enabled?('deprecated_no_dot_notation', 'some-lookup-key', { domain: 'example.com' })
   end
 
   def test_getting_feature_flag_value
@@ -375,7 +369,13 @@ class TestClient < Minitest::Test
   private
 
   def assert_equal_context_and_jit(expected, method, key, context)
-    assert_equal expected, @client.send(method, key, context)
+    if method == :get
+      assert_equal expected, @client.send(method, key, false, context)
+    elsif method == :enabled?
+      assert_equal expected, @client.send(method, key, context)
+    else
+      raise "unknown method #{method}"
+    end
 
     Prefab::Context.with_context(context) do
       assert_equal expected, @client.send(method, key)

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -25,11 +25,13 @@ class TestIntegration < Minitest::Test
               assert_match(/#{it.expected[:message]}/, err.message)
             when :nil
               assert_nil it.test_client.send(it.func, *it.input)
-            when :feature_flag
-              flag, context = *it.input
-              assert_equal it.expected[:value], it.test_client.send(it.func, flag, context)
             when :simple_equality
-              assert_equal it.expected[:value], it.test_client.send(it.func, *it.input)
+              if it.func == :enabled?
+                flag, _default, context = *it.input
+                assert_equal it.expected[:value], it.test_client.send(it.func, flag, context)
+              else
+                assert_equal it.expected[:value], it.test_client.send(it.func, *it.input)
+              end
             when :log_level
               assert_equal it.expected[:value].to_sym, it.test_client.send(it.func, *it.input)
             else


### PR DESCRIPTION
This has been deprecated for a long time now.

Also remove `with_log_context` for the same reason.
