### PR TITLE
Make expected warnings and logs explicit

### DIFF
--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -89,7 +89,7 @@ module Prefab
     end
 
     def _get(key, properties)
-      # wait timeout sec for the initalization to be complete
+      # wait timeout sec for the initialization to be complete
       @initialized_future.value(@options.initialization_timeout_sec)
       if @initialized_future.incomplete?
         unless @options.on_init_failure == Prefab::Options::ON_INITIALIZATION_FAILURE::RETURN

--- a/lib/prefab/config_resolver.rb
+++ b/lib/prefab/config_resolver.rb
@@ -10,6 +10,7 @@ module Prefab
       @config_loader = config_loader
       @project_env_id = 0 # we don't know this yet, it is set from the API results
       @base_client = base_client
+      @on_update = nil
       make_local
     end
 

--- a/test/support/common_helpers.rb
+++ b/test/support/common_helpers.rb
@@ -1,6 +1,32 @@
 # frozen_string_literal: true
 
 module CommonHelpers
+  require 'timecop'
+
+  def setup
+    $oldstderr, $stderr = $stderr, StringIO.new
+
+    $logs = nil
+    Timecop.freeze('2023-08-09 15:18:12 -0400')
+  end
+
+  def teardown
+    if $logs && !$logs.string.empty?
+      raise "Unexpected logs. Handle logs with assert_only_expected_logs or assert_logged\n\n#{$logs.string}"
+    end
+
+    if $stderr != $oldstderr && !$stderr.string.empty?
+      # we ignore 2.X because of the number of `instance variable @xyz not initialized` warnings
+      if !RUBY_VERSION.start_with?('2.')
+        raise "Unexpected stderr. Handle stderr with assert_stderr\n\n#{$stderr.string}"
+      end
+    end
+
+    $stderr = $oldstderr
+
+    Timecop.return
+  end
+
   def with_env(key, value, &block)
     old_value = ENV.fetch(key, nil)
 
@@ -18,10 +44,16 @@ module CommonHelpers
   }.freeze
 
   def new_client(overrides = {})
+    $logs ||= StringIO.new
+
     config = overrides.delete(:config)
     project_env_id = overrides.delete(:project_env_id)
 
-    options = Prefab::Options.new(**DEFAULT_NEW_CLIENT_OPTIONS.merge(overrides))
+    options = Prefab::Options.new(
+      **DEFAULT_NEW_CLIENT_OPTIONS.merge(
+        overrides.merge(logdev: $logs)
+      )
+    )
 
     Prefab::Client.new(options).tap do |client|
       inject_config(client, config) if config
@@ -51,26 +83,31 @@ module CommonHelpers
   FakeResponse = Struct.new(:status, :body)
 
   def wait_for_post_requests(client, max_wait: 2, sleep_time: 0.01)
-    requests = []
+    # we use ivars to avoid re-mocking the post method on subsequent calls
+    client.instance_variable_set("@_requests", [])
 
-    client.define_singleton_method(:post) do |*params|
-      requests.push(params)
+    if !client.instance_variable_get("@_already_faked_post")
+      client.define_singleton_method(:post) do |*params|
+        @_requests.push(params)
 
-      FakeResponse.new(200, '')
+        FakeResponse.new(200, '')
+      end
     end
+
+    client.instance_variable_set("@_already_faked_post", true)
 
     yield
 
     # let the flush thread run
     wait_time = 0
-    while requests.empty?
+    while client.instance_variable_get("@_requests").empty?
       wait_time += sleep_time
       sleep sleep_time
 
       raise "Waited #{max_wait} seconds for the flush thread to run, but it never did" if wait_time > max_wait
     end
 
-    requests
+    client.instance_variable_get("@_requests")
   end
 
   def assert_summary(client, data)
@@ -101,5 +138,37 @@ module CommonHelpers
 
   def context(properties)
     Prefab::Context.new(properties)
+  end
+
+  def assert_only_expected_logs
+    assert_equal "WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client No success loading checkpoints\n", $logs.string
+    # mark nil to indicate we handled it
+    $logs = nil
+  end
+
+  def assert_logged(expected)
+    # we do a uniq here because logging can happen in a separate thread so the
+    # number of times a log might happen could be slightly variable.
+    assert_equal expected, $logs.string.split("\n").uniq
+    # mark nil to indicate we handled it
+    $logs = nil
+  end
+
+  def assert_stderr(expected)
+    assert ($stderr.string.split("\n").uniq & expected).size > 0
+
+    # Ruby 2.X has a lot of warnings about instance variables not being
+    # initialized so we don't try to assert on stderr for those versions.
+    # Instead we just stop after asserting that our expected errors are
+    # included in the output.
+    if RUBY_VERSION.start_with?('2.')
+      puts $stderr.string
+      return
+    end
+
+    assert_equal expected, $stderr.string.split("\n")
+
+    # restore since we've handled it
+    $stderr = $oldstderr
   end
 end

--- a/test/test_config_client.rb
+++ b/test/test_config_client.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class TestConfigClient < Minitest::Test
   def setup
+    super
     options = Prefab::Options.new(
       prefab_config_override_dir: 'none',
       prefab_config_classpath_dir: 'test',

--- a/test/test_config_loader.rb
+++ b/test/test_config_loader.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class TestConfigLoader < Minitest::Test
   def setup
+    super
     options = Prefab::Options.new(
       prefab_config_override_dir: 'none',
       prefab_config_classpath_dir: 'test',

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -6,6 +6,7 @@ class TestContext < Minitest::Test
   EXAMPLE_PROPERTIES = { user: { key: 'some-user-key', name: 'Ted' }, team: { key: 'abc', plan: 'pro' } }.freeze
 
   def setup
+    super
     Prefab::Context.current = nil
   end
 

--- a/test/test_context_shape_aggregator.rb
+++ b/test/test_context_shape_aggregator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'timecop'
 
 class TestContextShapeAggregator < Minitest::Test
   DOB = Date.new
@@ -49,6 +50,8 @@ class TestContextShapeAggregator < Minitest::Test
 
     assert_equal [['user', 'name', 2], ['user', 'email', 2], ['user', 'age', 4], ['subscription', 'plan', 2], ['subscription', 'free', 5], ['user', 'dob', 2], ['device', 'name', 2], ['device', 'os', 2], ['device', 'version', 1]],
                  aggregator.data.to_a
+
+    assert_only_expected_logs
   end
 
   def test_prepare_data
@@ -82,6 +85,7 @@ class TestContextShapeAggregator < Minitest::Test
     }
 
     assert_equal [], aggregator.data.to_a
+    assert_only_expected_logs
   end
 
   def test_sync
@@ -117,6 +121,12 @@ class TestContextShapeAggregator < Minitest::Test
                                        ])
       ]
     ], requests
+
+
+    assert_logged [
+      "WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client No success loading checkpoints",
+      "WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client Couldn't Initialize In 0. Key some.key. Returning what we have"
+    ]
   end
 
   private
@@ -127,7 +137,7 @@ class TestContextShapeAggregator < Minitest::Test
       initialization_timeout_sec: 0,
       on_init_failure: Prefab::Options::ON_INITIALIZATION_FAILURE::RETURN,
       api_key: '123-development-yourapikey-SDK',
-      context_upload_mode: :shape_only,
+      context_upload_mode: :shape_only
     }.merge(overrides))
   end
 

--- a/test/test_criteria_evaluator.rb
+++ b/test/test_criteria_evaluator.rb
@@ -24,6 +24,7 @@ class TestCriteriaEvaluator < Minitest::Test
   )
 
   def setup
+    super
     @base_client = FakeBaseClient.new
   end
 

--- a/test/test_evaluated_keys_aggregator.rb
+++ b/test/test_evaluated_keys_aggregator.rb
@@ -17,6 +17,8 @@ class TestEvaluatedKeysAggregator < Minitest::Test
     # we've reached the limit, so no more
     aggregator.push('key.3')
     assert_equal 2, aggregator.data.size
+
+    assert_only_expected_logs
   end
 
   def test_sync
@@ -37,6 +39,12 @@ class TestEvaluatedKeysAggregator < Minitest::Test
         namespace: 'this.is.a.namespace'
       )
     ]], requests
+
+    assert_logged [
+      "WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client No success loading checkpoints",
+      "WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client Couldn't Initialize In 0. Key key.1. Returning what we have",
+      "WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client Couldn't Initialize In 0. Key key.2. Returning what we have"
+    ]
   end
 
   private

--- a/test/test_log_path_aggregator.rb
+++ b/test/test_log_path_aggregator.rb
@@ -8,7 +8,8 @@ class TestLogPathAggregator < Minitest::Test
   SLEEP_TIME = 0.01
 
   def test_push
-    aggregator = Prefab::LogPathAggregator.new(client: new_client, max_paths: 2, sync_interval: 1000)
+    client = new_client
+    aggregator = Prefab::LogPathAggregator.new(client: client, max_paths: 2, sync_interval: 1000)
 
     aggregator.push('test.test_log_path_aggregator.test_push.1', ::Logger::INFO)
     aggregator.push('test.test_log_path_aggregator.test_push.2', ::Logger::DEBUG)
@@ -18,6 +19,8 @@ class TestLogPathAggregator < Minitest::Test
     # we've reached the limit, so no more
     aggregator.push('test.test_log_path_aggregator.test_push.3', ::Logger::INFO)
     assert_equal 2, aggregator.data.size
+
+    assert_only_expected_logs
   end
 
   def test_sync
@@ -42,6 +45,11 @@ class TestLogPathAggregator < Minitest::Test
           namespace: 'this.is.a.namespace'
         )
       ]], requests
+
+      assert_logged [
+        'WARN  2023-08-09 15:18:12 -0400: cloud.prefab.client No success loading checkpoints',
+        'ERROR 2023-08-09 15:18:12 -0400: test.test_log_path_aggregator.test_sync here is a message'
+      ]
     end
   end
 

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -19,6 +19,7 @@ class TestLogger < Minitest::Test
   )
 
   def setup
+    super
     Prefab::LoggerClient.send(:public, :get_path)
     Prefab::LoggerClient.send(:public, :get_loc_path)
     Prefab::LoggerClient.send(:public, :level_of)


### PR DESCRIPTION
This cleans up test output and keeps us accountable for our verbosity
