### PR TITLE
Change collect_evaluation_summaries to default to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Change `collect_evaluation_summaries` default to true (#136)
+- Removed some backwards compatibility shims (#133)
+- Standardizing options (#132)
+  - Note that the default value for `context_upload_mode` is `:periodic_example` which means example contexts will be collected.
+    This enables easy variant override assignment in our UI. More at https://prefab.cloud/blog/feature-flag-variant-assignment/
+
 ## 0.24.6 - 2023-07-31
 
 - Logger Client compatibility (#129)

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -71,7 +71,7 @@ module Prefab
       collect_max_keys: DEFAULT_MAX_KEYS,
       context_upload_mode: :periodic_example, # :periodic_example, :shape_only, :none
       context_max_size: DEFAULT_MAX_EVAL_SUMMARIES,
-      collect_evaluation_summaries: false,
+      collect_evaluation_summaries: true,
       collect_max_evaluation_summaries: DEFAULT_MAX_EVAL_SUMMARIES,
       allow_telemetry_in_local_mode: false
     )

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -43,11 +43,10 @@ class TestOptions < Minitest::Test
   end
 
   def test_collect_max_evaluation_summaries
-    assert_equal 0, Prefab::Options.new.collect_max_evaluation_summaries
-    assert_equal 100_000, Prefab::Options.new(collect_evaluation_summaries: true).collect_max_evaluation_summaries
+    assert_equal 100_000, Prefab::Options.new.collect_max_evaluation_summaries
+    assert_equal 0, Prefab::Options.new(collect_evaluation_summaries: false).collect_max_evaluation_summaries
     assert_equal 3,
-                 Prefab::Options.new(collect_evaluation_summaries: true,
-                                     collect_max_evaluation_summaries: 3).collect_max_evaluation_summaries
+                 Prefab::Options.new(collect_max_evaluation_summaries: 3).collect_max_evaluation_summaries
   end
 
   def test_context_upload_mode_periodic


### PR DESCRIPTION
This sends summaries of flag evaluations to drive the Contexts UI on
prefab.cloud where you can see recent flag evaluations for a user.
