### PR TITLE
Add integration test harness for testing telemetry endpoints

### DIFF
--- a/lib/prefab/context_shape_aggregator.rb
+++ b/lib/prefab/context_shape_aggregator.rb
@@ -54,7 +54,7 @@ module Prefab
           end
         )
 
-        result = @client.post('/api/v1/context-shapes', shapes)
+        result = post('/api/v1/context-shapes', shapes)
 
         log_internal "Uploaded #{to_ship.values.size} shapes: #{result.status}"
       end

--- a/lib/prefab/evaluation_summary_aggregator.rb
+++ b/lib/prefab/evaluation_summary_aggregator.rb
@@ -55,7 +55,7 @@ module Prefab
           summaries: summaries(to_ship)
         )
 
-        result = @client.post('/api/v1/telemetry', events(summaries_proto))
+        result = post('/api/v1/telemetry', events(summaries_proto))
 
         log_internal "Uploaded #{to_ship.size} summaries: #{result.status}"
       end

--- a/lib/prefab/example_contexts_aggregator.rb
+++ b/lib/prefab/example_contexts_aggregator.rb
@@ -45,7 +45,7 @@ module Prefab
       pool.post do
         log_internal "Flushing #{to_ship.size} examples"
 
-        result = @client.post('/api/v1/telemetry', events(to_ship))
+        result = post('/api/v1/telemetry', events(to_ship))
 
         log_internal "Uploaded #{to_ship.size} examples: #{result.status}"
       end

--- a/lib/prefab/log_path_aggregator.rb
+++ b/lib/prefab/log_path_aggregator.rb
@@ -25,6 +25,9 @@ module Prefab
 
       @data = Concurrent::Map.new
 
+      @last_data_sent = nil
+      @last_request = nil
+
       start_periodic_sync(sync_interval)
     end
 
@@ -55,7 +58,7 @@ module Prefab
           namespace: @client.namespace
         )
 
-        result = @client.post('/api/v1/known-loggers', loggers)
+        result = post('/api/v1/known-loggers', loggers)
 
         log_internal "Uploaded #{to_ship.size} paths: #{result.status}"
       end

--- a/lib/prefab/periodic_sync.rb
+++ b/lib/prefab/periodic_sync.rb
@@ -26,6 +26,10 @@ module Prefab
       # noop -- override as you wish
     end
 
+    def post(url, data)
+      @client.post(url, data)
+    end
+
     def start_periodic_sync(sync_interval)
       @start_at = Prefab::TimeHelpers.now_in_ms
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 
 class IntegrationTest
-  attr_reader :func, :input, :expected, :test_client
+  attr_reader :func, :input, :expected, :data, :expected_data, :aggregator, :endpoint, :test_client
 
   def initialize(test_data)
     @client_overrides = parse_client_overrides(test_data['client_overrides'])
     @func = parse_function(test_data['function'])
     @input = parse_input(test_data['input'])
     @expected = parse_expected(test_data['expected'])
-    @test_client = base_client
+    @data = test_data['data']
+    @expected_data = test_data['expected_data']
+    @aggregator = test_data['aggregator']
+    @endpoint = test_data['endpoint']
+    @test_client = capture_telemetry(base_client)
   end
 
   def test_type
-    if @input[0] && @input[0].start_with?('log-level.')
+    if @data
+      :telemetry
+    elsif @input[0] && @input[0].start_with?('log-level.')
       :log_level
     elsif @expected[:status] == 'raise'
       :raise
@@ -21,6 +27,18 @@ class IntegrationTest
     else
       :simple_equality
     end
+  end
+
+  def last_data_sent
+    test_client.last_data_sent
+  end
+
+  def last_post_result
+    test_client.last_post_result
+  end
+
+  def last_post_endpoint
+    test_client.last_post_endpoint
   end
 
   private
@@ -42,6 +60,8 @@ class IntegrationTest
   end
 
   def parse_input(input)
+    return nil if input.nil?
+
     if input['key']
       parse_config_input(input)
     elsif input['flag']
@@ -62,6 +82,8 @@ class IntegrationTest
   end
 
   def parse_expected(expected)
+    return {} if expected.nil?
+
     {
       status: expected['status'],
       error: parse_error_type(expected['error']),
@@ -73,6 +95,7 @@ class IntegrationTest
   def parse_error_type(error_type)
     case error_type
     when 'missing_default' then Prefab::Errors::MissingDefaultError
+    when 'initialization_timeout' then Prefab::Errors::InitializationTimeoutError
     end
   end
 
@@ -87,7 +110,34 @@ class IntegrationTest
       prefab_envs: ['unit_tests'],
       prefab_datasources: Prefab::Options::DATASOURCES::ALL,
       api_key: ENV['PREFAB_INTEGRATION_TEST_API_KEY'],
-      prefab_api_url: 'https://api.staging-prefab.cloud'
+      prefab_api_url: 'https://api.staging-prefab.cloud',
     }.merge(@client_overrides))
+  end
+
+  def capture_telemetry(client)
+    client.define_singleton_method(:post) do |url, data|
+      client.instance_variable_set(:@last_data_sent, data)
+      client.instance_variable_set(:@last_post_endpoint, url)
+
+      result = super(url, data)
+
+      client.instance_variable_set(:@last_post_result, result)
+
+      result
+    end
+
+    client.define_singleton_method(:last_data_sent) do
+      client.instance_variable_get(:@last_data_sent)
+    end
+
+    client.define_singleton_method(:last_post_endpoint) do
+      client.instance_variable_get(:@last_post_endpoint)
+    end
+
+    client.define_singleton_method(:last_post_result) do
+      client.instance_variable_get(:@last_post_result)
+    end
+
+    client
   end
 end

--- a/test/integration_test_helpers.rb
+++ b/test/integration_test_helpers.rb
@@ -33,4 +33,117 @@ module IntegrationTestHelpers
         .select { |file| file =~ /\.ya?ml$/ }
     end
   end
+
+  def self.prepare_post_data(it)
+    case it.aggregator
+    when "log_path"
+      aggregator = it.test_client.log_path_aggregator
+
+      it.data.each do |(path, data)|
+        data.each_with_index do |count, severity|
+          count.times { aggregator.push(path, severity) }
+        end
+      end
+
+      expected_loggers = Hash.new { |h, k| h[k] = PrefabProto::Logger.new }
+
+      it.expected_data.each do |data|
+        data["counts"].each do |(severity, count)|
+          expected_loggers[data["logger_name"]][severity] = count
+          expected_loggers[data["logger_name"]]["logger_name"] = data["logger_name"]
+        end
+      end
+
+      [aggregator, ->(data) { data.loggers }, expected_loggers.values]
+    when "context_shape"
+      aggregator = it.test_client.context_shape_aggregator
+
+      context = Prefab::Context.new(it.data)
+
+      aggregator.push(context)
+
+      expected = it.expected_data.map do |data|
+        PrefabProto::ContextShape.new(
+          name: data["name"],
+          field_types: data["field_types"]
+        )
+      end
+
+      [aggregator, ->(data) { data.shapes }, expected]
+    when "evaluation_summary"
+      aggregator = it.test_client.evaluation_summary_aggregator
+
+      aggregator.instance_variable_set("@data", Concurrent::Hash.new)
+
+      it.data.each do |key|
+        it.test_client.get(key)
+      end
+
+      expected_data = []
+      it.expected_data.each do |data|
+        value = if data["value_type"] == "string_list"
+                  PrefabProto::StringList.new(values: data["value"])
+                else
+                  data["value"]
+                end
+        expected_data << PrefabProto::ConfigEvaluationSummary.new(
+          key: data["key"],
+          type: data["type"].to_sym,
+          counters: [
+            PrefabProto::ConfigEvaluationCounter.new(
+              count: data["count"],
+              config_id: 0,
+              selected_value: PrefabProto::ConfigValue.new(data["value_type"] => value),
+              config_row_index: data["summary"]["config_row_index"],
+              conditional_value_index: data["summary"]["conditional_value_index"] || 0,
+              weighted_value_index: data["summary"]["weighted_value_index"],
+              reason: :UNKNOWN
+            )
+          ]
+        )
+      end
+
+      [aggregator, ->(data) {
+                     data.events[0].summaries.summaries.each { |e|
+                       e.counters.each { |c|
+                         c.config_id = 0
+                       }
+                     }
+                   }, expected_data]
+    when "example_contexts"
+      aggregator = it.test_client.example_contexts_aggregator
+
+      it.data.each do |hash|
+        aggregator.record(Prefab::Context.new(hash))
+      end
+
+      expected_data = []
+      it.expected_data.each do |data|
+        expected_data << PrefabProto::ExampleContext.new(
+          timestamp: 0,
+          contextSet: PrefabProto::ContextSet.new(
+            contexts: data.map do |(k, vs)|
+              PrefabProto::Context.new(
+                type: k,
+                values: vs.map do |v|
+                  [v["key"], PrefabProto::ConfigValue.new(v["value_type"] => v["value"])]
+                end.to_h
+              )
+            end
+          )
+        )
+      end
+      [aggregator, ->(data) { data.events[0].example_contexts.examples.each { |e| e.timestamp = 0 } }, expected_data]
+    else
+      puts "unknown aggregator #{it.aggregator}"
+    end
+  end
+
+  def self.with_parent_context_maybe(context, &block)
+    if context
+      Prefab::Context.with_context(context, &block)
+    else
+      yield
+    end
+  end
 end


### PR DESCRIPTION
Add integration test harness for testing telemetry endpoints

* Also add tests for confirming timeout exceptions are handled correctly
* Point integration test data to tag v0.2.2