### PR TITLE
Don't remember last payload for telemetry

### DIFF
--- a/lib/prefab/context_shape_aggregator.rb
+++ b/lib/prefab/context_shape_aggregator.rb
@@ -57,7 +57,7 @@ module Prefab
           end
         )
 
-        post_and_persist_data('/api/v1/context-shapes', shapes)
+        result = post('/api/v1/context-shapes', shapes)
 
         log_internal "Uploaded #{to_ship.values.size} shapes: #{result.status}"
       end

--- a/lib/prefab/evaluation_summary_aggregator.rb
+++ b/lib/prefab/evaluation_summary_aggregator.rb
@@ -55,7 +55,7 @@ module Prefab
           summaries: summaries(to_ship)
         )
 
-        post_and_persist_data('/api/v1/telemetry', events(summaries_proto))
+        result = post('/api/v1/telemetry', events(summaries_proto))
 
         log_internal "Uploaded #{to_ship.size} summaries: #{result.status}"
       end

--- a/lib/prefab/example_contexts_aggregator.rb
+++ b/lib/prefab/example_contexts_aggregator.rb
@@ -45,7 +45,7 @@ module Prefab
       pool.post do
         log_internal "Flushing #{to_ship.size} examples"
 
-        post_and_persist_data('/api/v1/telemetry', events(to_ship))
+        result = post('/api/v1/telemetry', events(to_ship))
 
         log_internal "Uploaded #{to_ship.size} examples: #{result.status}"
       end

--- a/lib/prefab/log_path_aggregator.rb
+++ b/lib/prefab/log_path_aggregator.rb
@@ -45,7 +45,6 @@ module Prefab
 
         aggregate = Hash.new { |h, k| h[k] = PrefabProto::Logger.new }
 
-
         to_ship.each do |(path, severity), count|
           aggregate[path][SEVERITY_KEY[severity]] = count
           aggregate[path]['logger_name'] = path
@@ -59,7 +58,7 @@ module Prefab
           namespace: @client.namespace
         )
 
-        post_and_persist_data('/api/v1/known-loggers', loggers)
+        result = post('/api/v1/known-loggers', loggers)
 
         log_internal "Uploaded #{to_ship.size} paths: #{result.status}"
       end

--- a/lib/prefab/periodic_sync.rb
+++ b/lib/prefab/periodic_sync.rb
@@ -2,11 +2,7 @@
 
 module Prefab
   module PeriodicSync
-
-    attr_reader :last_data_sent, :last_request
-
     def sync
-
       return if @data.size.zero?
 
       log_internal "Syncing #{@data.size} items"
@@ -30,12 +26,8 @@ module Prefab
       # noop -- override as you wish
     end
 
-    def post_and_persist_data(url, data)
-      @last_data_sent = data
-
-      result = @client.post(url, data)
-
-      @last_request = result
+    def post(url, data)
+      @client.post(url, data)
     end
 
     def start_periodic_sync(sync_interval)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IntegrationTest
-  attr_reader :func, :input, :expected, :data, :expected_data, :aggregator, :test_client
+  attr_reader :func, :input, :expected, :data, :expected_data, :aggregator, :endpoint, :test_client
 
   def initialize(test_data)
     @client_overrides = parse_client_overrides(test_data['client_overrides'])
@@ -11,6 +11,7 @@ class IntegrationTest
     @data = test_data['data']
     @expected_data = test_data['expected_data']
     @aggregator = test_data['aggregator']
+    @endpoint = test_data['endpoint']
     @test_client = capture_telemetry(base_client)
   end
 

--- a/test/integration_test_helpers.rb
+++ b/test/integration_test_helpers.rb
@@ -102,7 +102,13 @@ module IntegrationTestHelpers
         )
       end
 
-      [aggregator, ->(data) { data.events[0].summaries.summaries.each {|e| e.counters.each{|c| c.config_id = 0}} }, expected_data]
+      [aggregator, ->(data) {
+                     data.events[0].summaries.summaries.each { |e|
+                       e.counters.each { |c|
+                         c.config_id = 0
+                       }
+                     }
+                   }, expected_data]
     when "example_contexts"
       aggregator = it.test_client.example_contexts_aggregator
 
@@ -126,7 +132,7 @@ module IntegrationTestHelpers
           )
         )
       end
-      [aggregator, ->(data) { data.events[0].example_contexts.examples.each {|e| e.timestamp = 0}  }, expected_data]
+      [aggregator, ->(data) { data.events[0].example_contexts.examples.each { |e| e.timestamp = 0 } }, expected_data]
     else
       puts "unknown aggregator #{it.aggregator}"
     end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -40,8 +40,7 @@ class TestIntegration < Minitest::Test
 
               wait_for -> { it.last_post_result&.status == 200 }
 
-              # TODO: endpoint assertion
-              # assert_equal it.expected[:last_post_endpoint], it.last_post_endpoint
+              assert it.endpoint == it.last_post_endpoint
 
               actual = get_actual_data[it.last_data_sent]
 

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -38,11 +38,13 @@ class TestIntegration < Minitest::Test
               aggregator, get_actual_data, expected = IntegrationTestHelpers.prepare_post_data(it)
               aggregator.sync
 
-              sleep(1)
+              wait_for -> { it.last_post_result&.status == 200 }
 
-              actual = get_actual_data[aggregator.last_data_sent]
+              # TODO: endpoint assertion
+              # assert_equal it.expected[:last_post_endpoint], it.last_post_endpoint
 
-              assert aggregator.last_request.status == 200
+              actual = get_actual_data[it.last_data_sent]
+
               expected.all? do |expected|
                 assert actual.include?(expected)
               end


### PR DESCRIPTION
The remembering approach is generally fine, but I have a small worry about bloating memory when aggregators have high volume.

Instead, for integration tests, we'll override the default client `post` implementation and capture the params and result.

I also left a #TODO here around making an assertion of the endpoint we're posting too. Feels like a good thing to have.

Pardon the occasional rubocop formatting noise.