### PR TITLE
Add basic support for structured logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add support for structured logging (#143)
+    - Ability to pass a hash of key/value context pairs to any of the user-facing log methods
+
+
 ## 1.0.1 - 2023-08-17
 
 - Bug fix for StringList w/ ExampleContextsAggregator (#141)

--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -99,8 +99,8 @@ module Prefab
       resolver.on_update(&block)
     end
 
-    def log_internal(level, msg, path = nil)
-      log.log_internal msg, path, nil, level
+    def log_internal(level, msg, path = nil, **tags)
+      log.log_internal msg, path, nil, level, tags
     end
 
     def enabled?(feature_name, jit_context = NO_DEFAULT_PROVIDED)


### PR DESCRIPTION
These changes allow any of our existing top-level log methods (`log_internal`, `log.info`, `log.warn`, etc.) to additionally take a hash of tags, which are added to the output log, either as an addendum to a text log line, or merged with the rest of the log in the event of JSON.

Also refactors the default formatters to accept a single data hash, rather than a variable number of discrete arguments, moving some of the parsing logic for that data into the formatters themselves.

Also
===

Add a test for the JSON formatter output
