### PR TITLE
Support running tests from RubyMine

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@
 require 'minitest/autorun'
 require 'minitest/focus'
 require 'minitest/reporters'
-Minitest::Reporters.use!
+Minitest::Reporters.use! unless ENV['RM_INFO']
 
 require 'prefab-cloud-ruby'
 


### PR DESCRIPTION
RubyMine test runner doesn't like this, but helpfully supplies an EnvVar so we can avoid it.