### PR TITLE
Log evaluations from the criteria evaluator.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-export AWS_ACCESS_KEY_ID=
-export AWS_SECRET_ACCESS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ gen_protos.sh
 lib/tes*
 .envrc
 .tool-versions
+.env*

--- a/lib/prefab/criteria_evaluator.rb
+++ b/lib/prefab/criteria_evaluator.rb
@@ -19,8 +19,10 @@ module Prefab
     end
 
     def evaluate(properties)
-      evaluate_for_env(@project_env_id, properties) ||
+      rtn = evaluate_for_env(@project_env_id, properties) ||
         evaluate_for_env(0, properties)
+      @base_client.log_internal ::Logger::DEBUG, "Eval Key #{@config.key} Result #{rtn&.value} with #{properties.to_h}", :criteria_evaluator unless @config.config_type == :LOG_LEVEL
+      rtn
     end
 
     def all_criteria_match?(conditional_value, props)

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -38,7 +38,6 @@ module Prefab
     end
 
     def log_internal(message, path, progname, severity, log_context={}, &block)
-      @recurse_check[local_log_id] ||= false
       return if @recurse_check[local_log_id]
       @recurse_check[local_log_id] = true
 

--- a/test/support/mock_base_client.rb
+++ b/test/support/mock_base_client.rb
@@ -30,7 +30,7 @@ class MockBaseClient
     @logger
   end
 
-  def log_internal(level, message); end
+  def log_internal(level, msg, path = nil, **tags); end
 
   def context_shape_aggregator; end
 

--- a/test/test_criteria_evaluator.rb
+++ b/test/test_criteria_evaluator.rb
@@ -724,6 +724,8 @@ class TestCriteriaEvaluator < Minitest::Test
       FakeLogger.new
     end
 
+    def log_internal(level, msg, path = nil, **tags); end
+
     def evaluation_summary_aggregator
       @evaluation_summary_aggregator ||= Prefab::EvaluationSummaryAggregator.new(client: self, max_keys: 9999, sync_interval: 9999)
     end


### PR DESCRIPTION
Recursion check to allow internal logging.

Turn `cloud.prefab.client.criteria_evaluator ` to debug to get output showing the evaluated context. 

```
DEBUG 2023-10-11 17:14:57 -0400: cloud.prefab.client.criteria_evaluator Eval Key ex2.homepage-h1 Result <PrefabProto::ConfigValue: string: "ForceRank is a Stack Ranking Tool for Leadership Teams"> with {"user"=>{"id"=>nil, "email"=>nil, "key"=>"1", "name"=>nil}, "request"=>{"key"=>"home#index"}, "application"=>{"key"=>"forcerank-app", "type"=>"web"}}
```