### PR TITLE
send back logger aggregation for internal logging too.

### DIFF
--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -56,8 +56,6 @@ module Prefab
       path_loc = get_loc_path(loc)
       path = @prefix + path_loc
 
-      @log_path_aggregator&.push(path_loc, severity)
-
       log(message, path, progname, severity, log_context, &block)
     end
 
@@ -73,6 +71,8 @@ module Prefab
 
     def log(message, path, progname, severity, log_context={})
       severity ||= ::Logger::UNKNOWN
+      @log_path_aggregator&.push(path, severity)
+
       return true if @logdev.nil? || severity < level_of(path) || @silences[local_log_id]
 
       progname = @progname if progname.nil?


### PR DESCRIPTION
`cloud.prefab.*` wasn't sending back a known logger which made users need to manually add the logger in order to control from UI. 

our internal static logger `rails.controller` was also not being sent back. 