### PR TITLE
Jd/log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Compact Log Format (#163)
 - Tagged Logging (#161)
 - ContextKey logging thread safety (#162)
 

--- a/lib/prefab/logger_client.rb
+++ b/lib/prefab/logger_client.rb
@@ -233,14 +233,14 @@ module Prefab
 
     def format_message(severity, datetime, progname, msg, path = nil, log_context = {})
       formatter = (@formatter || @default_formatter)
-
+      compact_context = log_context.reject{ |_, v| v.nil? || ((v.is_a? Array) && v.empty?) }
       formatter.call(
         severity: severity,
         datetime: datetime,
         progname: progname,
         path: path,
         message: msg,
-        log_context: log_context
+        log_context: compact_context
       )
     end
   end

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -32,8 +32,8 @@ module Prefab
       progname = (progname.nil? || progname.empty?) ? path : "#{progname}: #{path}"
 
       formatted_log_context = log_context.sort.map do |k, v|
-        v.nil? || ((v.is_a? Array) && v.empty?) ? nil : "#{k}=#{v}"
-      end.compact.join(" ")
+        "#{k}=#{v}"
+      end.join(" ")
       "#{severity.ljust(5)} #{datetime}:#{' ' if progname}#{progname} #{msg}#{log_context.any? ? " " + formatted_log_context : ""}\n"
     }
 

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -42,6 +42,18 @@ module Prefab
       data.merge(log_context).compact.to_json << "\n"
     }
 
+    COMPACT_LOG_FORMATTER = proc { |data|
+      severity = data[:severity]
+      msg = data[:message]
+      log_context = data[:log_context]
+      log_context["path"] = data[:path] || ""
+
+      formatted_log_context = log_context.sort.map do |k, v|
+        "#{k}=#{v}"
+      end.join(" ")
+      "#{severity.ljust(5)} #{msg&.strip} #{formatted_log_context}\n"
+    }
+
     module ON_INITIALIZATION_FAILURE
       RAISE = :raise
       RETURN = :return


### PR DESCRIPTION
A simpler formatter intended for human readability in local development.

COMPACT_LOG_FORMATTER
```
DEBUG ↳ app/controllers/posts_controller.rb:6:in `index' path=active_record.log_subscriber.log_query_source
INFO  🍋🍋🍋Info Log in posts#index path=app.controllers.posts_controller.index posts=1
DEBUG CACHE Post Count (0.0ms)  SELECT COUNT(*) FROM "posts" path=active_support.log_subscriber.debug
DEBUG ↳ app/controllers/posts_controller.rb:7:in `index' path=active_record.log_subscriber.log_query_source
WARN  🍑🍑🍑Warn Log in posts#index path=app.controllers.posts_controller.index posts=1
DEBUG CACHE Post Count (0.0ms)  SELECT COUNT(*) FROM "posts" path=active_support.log_subscriber.debug
DEBUG ↳ app/controllers/posts_controller.rb:8:in `index' path=active_record.log_subscriber.log_query_source
ERROR 🍓🍓🍓Error Log in posts#index path=app.controllers.posts_controller.index posts=1
```

DEFAULT_LOG_FORMATTER
```
DEBUG 2023-11-20 13:02:19 -0500: active_record.log_subscriber.log_query_source   ↳ app/controllers/posts_controller.rb:11:in `index' 
WARN  2023-11-20 13:02:19 -0500: app.controllers.posts_controller.index 🍑🍑🍑Warn Log in posts#index 1 
DEBUG 2023-11-20 13:02:19 -0500: active_support.log_subscriber.debug   CACHE Post Count (0.0ms)  SELECT COUNT(*) FROM "posts" 
DEBUG 2023-11-20 13:02:19 -0500: active_record.log_subscriber.log_query_source   ↳ app/controllers/posts_controller.rb:12:in `index' 
ERROR 2023-11-20 13:02:19 -0500: app.controllers.posts_controller.index 🍓🍓🍓Error Log in posts#index 1 
```