### PR TITLE
chore(secrets): Use reportable value even for invalid data

### DIFF
--- a/lib/prefab/config_value_unwrapper.rb
+++ b/lib/prefab/config_value_unwrapper.rb
@@ -13,9 +13,9 @@ module Prefab
     end
 
     def reportable_wrapped_value
-      if @config_value.confidential
+      if @config_value.confidential || @config_value.decrypt_with&.length&.positive?
         # Unique hash for differentiation
-        Prefab::ConfigValueWrapper.wrap("#{CONFIDENTIAL_PREFIX}#{Digest::MD5.hexdigest(unwrap)[0,5]}")
+        Prefab::ConfigValueWrapper.wrap("#{CONFIDENTIAL_PREFIX}#{Digest::MD5.hexdigest(unwrap)[0, 5]}")
       else
         @config_value
       end
@@ -52,7 +52,6 @@ module Prefab
       end
 
       raw
-
     end
 
     def self.deepest_value(config_value, config, context, resolver)
@@ -100,7 +99,7 @@ module Prefab
       when :BOOL then
         maybe_bool = YAML.load(value_string)
         case maybe_bool
-        when TrueClass,FalseClass
+        when TrueClass, FalseClass
           maybe_bool
         else
           raise Prefab::Errors::EnvVarParseError.new(value_string, config, env_var_name)

--- a/test/test_config_value_unwrapper.rb
+++ b/test/test_config_value_unwrapper.rb
@@ -162,6 +162,7 @@ class TestConfigValueUnwrapper < Minitest::Test
     encrypted = Prefab::Encryption.new(DECRYPTION_KEY_VALUE).encrypt(clear_text)
     config_value = PrefabProto::ConfigValue.new(string: encrypted, decrypt_with: "decryption.key")
     assert_equal clear_text, unwrap(config_value, CONFIG, EMPTY_CONTEXT)
+    assert reportable_value(config_value, CONFIG, EMPTY_CONTEXT).start_with? Prefab::ConfigValueUnwrapper::CONFIDENTIAL_PREFIX
   end
 
   def test_confidential


### PR DESCRIPTION
All secrets should be `confidential` but either way, don't report them
