### PR TITLE
fix: Don't crash printing invalid config on load

### DIFF
--- a/lib/prefab/resolved_config_presenter.rb
+++ b/lib/prefab/resolved_config_presenter.rb
@@ -65,7 +65,11 @@ module Prefab
             if v.nil?
               elements << 'tombstone'
             else
-              value = @resolver.evaluate(v[:config])&.reportable_value
+              value = begin
+                @resolver.evaluate(v[:config])&.reportable_value
+              rescue StandardError => e
+                "ERROR EVALUATING: #{e.class} #{e.message}"
+              end
               elements << value.to_s.slice(0..34).ljust(35)
               elements << value.class.to_s.slice(0..6).ljust(7)
               elements << "Match: #{v[:match]}".slice(0..29).ljust(30)


### PR DESCRIPTION
Instead, indicate the problem. This can still crash on evaluation, but
the case is truly exceptional.

We've intentionally set bad data in the integration tests to get into an
invalid state that represents this behavior.

```
a.broken.secret.config | ERROR EVALUATING: OpenSSL::Cipher::CipherError | String  | Match: | Source: remote_cdn_api
```
