### PR TITLE
chore: Context consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.0 - 2024-02-12
+
+- Fix potential inconsistent Context behavior (#172)
+
 ## 1.4.5 - 2024-01-31
 
 - Refactor out a `should_log?` method (#170)

--- a/lib/prefab/config_resolver.rb
+++ b/lib/prefab/config_resolver.rb
@@ -61,8 +61,6 @@ module Prefab
     def make_context(properties)
       if properties == NO_DEFAULT_PROVIDED || properties.nil?
         Context.current
-      elsif properties.is_a?(Context)
-        properties
       else
         Context.merge_with_current(properties)
       end.merge_default(default_context || {})

--- a/lib/prefab/context.rb
+++ b/lib/prefab/context.rb
@@ -73,7 +73,7 @@ module Prefab
       end
 
       def merge_with_current(new_context_properties = {})
-        new(current.to_h.merge(new_context_properties))
+        new(current.to_h.merge(new_context_properties.to_h))
       end
     end
 


### PR DESCRIPTION
If passed a `Context` object as a param to `get`, it would ignore the
thread-local context.

I don't expect anyone actually has done that (the docs all use hashes)
but this behavior should be consistent regardless of whether you pass a
`Context` object or a hash.
