### PR TITLE
fix: send context shapes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: Send context shapes by default
+
 ## 1.5.0 - 2024-02-12
 
 - Fix potential inconsistent Context behavior (#172)

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -136,6 +136,8 @@ module Prefab
       when :periodic_example
         @collect_example_contexts = true
         @collect_max_example_contexts = context_max_size
+        @collect_shapes = true
+        @collect_max_shapes = context_max_size
       when :shape_only
         @collect_shapes = true
         @collect_max_shapes = context_max_size


### PR DESCRIPTION
In the future, this might be served by periodic_example at the telemetry API-level, but right now we want to send both.
