### PR TITLE
Add global context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'google-protobuf', platforms: :ruby
 gem 'ld-eventsource'
 gem 'uuid'
 
-gem 'activesupport', '>= 4'
+gem 'activesupport',  '>= 4'
 gem 'actionpack',  '>= 4'
 
 gem 'semantic_logger', require: "semantic_logger/sync"
@@ -18,7 +18,6 @@ group :development do
   gem 'juwelier', '~> 2.4.9'
   gem 'rdoc'
   gem 'simplecov', '>= 0'
-  gem "allocation_stats"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    allocation_stats (0.1.5)
     ansi (1.5.0)
     base64 (0.2.0)
-    benchmark-ips (2.13.0)
+    benchmark-ips (2.10.0)
     bigdecimal (3.1.4)
     builder (3.2.4)
     concurrent-ruby (1.1.10)
@@ -171,7 +170,6 @@ PLATFORMS
 DEPENDENCIES
   actionpack (>= 4)
   activesupport (>= 4)
-  allocation_stats
   benchmark-ips
   bundler
   concurrent-ruby (~> 1.0, >= 1.0.5)

--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -29,6 +29,9 @@ module Prefab
       end
 
       context.clear
+
+      Prefab::Context.global_context = @options.global_context
+
       # start config client
       config_client
     end

--- a/lib/prefab/evaluation.rb
+++ b/lib/prefab/evaluation.rb
@@ -3,7 +3,7 @@
 module Prefab
   # Records the result of evaluating a config's criteria and forensics for reporting
   class Evaluation
-    attr_reader :value
+    attr_reader :value, :context
 
     def initialize(config:, value:, value_index:, config_row_index:, context:, resolver:)
       @config = config
@@ -32,6 +32,7 @@ module Prefab
 
     def report(evaluation_summary_aggregator)
       return if @config.config_type == :LOG_LEVEL
+
       evaluation_summary_aggregator&.record(
         config_key: @config.key,
         config_type: @config.config_type,

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -16,6 +16,7 @@ module Prefab
     attr_reader :use_local_cache
     attr_reader :datafile
     attr_reader :disable_action_controller_logging
+    attr_reader :global_context
     attr_accessor :is_fork
 
     module ON_INITIALIZATION_FAILURE
@@ -59,7 +60,8 @@ module Prefab
       allow_telemetry_in_local_mode: false,
       x_datafile: ENV['PREFAB_DATAFILE'],
       x_use_local_cache: false,
-      disable_action_controller_logging: false
+      disable_action_controller_logging: false,
+      global_context: {}
     )
       @api_key = api_key
       @namespace = namespace
@@ -81,6 +83,7 @@ module Prefab
       @use_local_cache = x_use_local_cache
       @disable_action_controller_logging = disable_action_controller_logging
       @is_fork = false
+      @global_context = global_context
 
       # defaults that may be overridden by context_upload_mode
       @collect_shapes = false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ Dir.glob(File.join(File.dirname(__FILE__), 'support', '**', '*.rb')).each do |fi
   require file
 end
 
-MiniTest::Test.class_eval do
+Minitest::Test.class_eval do
   include CommonHelpers
   extend CommonHelpers
 end


### PR DESCRIPTION
As a user, you can provide three contexts:

1. `global_context`: set at initialization time and immutable
2. `Prefab.with_context`: a block-level context you can set at will
3. Just-in-time (jit) context: provided inline during a lookup. e.g.  `prefab.get("some-key", {"user"=>{"name"=>"Frank"}})`

Additionally, a `default_context` is provided by the API.
`default_context` is the highest level besides `global_context`

---

An example lookup tree might be set up like so:

```ruby
Prefab.init(global_context: {"cpu"=>{"count"=>4, "speed"=>"2.4GHz"}, "clock"=>{"timezone"=>"UTC"}})

Prefab.with_context({"clock"=>{"timezone"=>"PST"}, "user"=>{"name"=>"Ted", "email"=>"ted@example.com"}}) do
  prefab.get("some-key", {"user"=>{"name"=>"Frank"}})
end
```

The resolution tree looks like this:

```
| jit:                  {"user"=>{"name"=>"Frank"}}
|-- block:              {"clock"=>{"timezone"=>"PST"}, "user"=>{"name"=>"Ted", "email"=>"ted@example.com"}}
|---- default_context:  {"prefab-api-key"=>{"user-id"=>123}}
|------ global_context: {"cpu"=>{"count"=>4, "speed"=>"2.4GHz"}, "clock"=>{"timezone"=>"UTC"}}
```

Some example resolutions:

- `user.name` resolves to "Frank" via the `jit` context.
- `clock.timezone` resolves to "PST" by virtue of the `block` context (`Prefab.with_context`)
- `user.email` resolves to `nil` because the `jit` context clobbers the `user` namespace for the `block` context
- `prefab-api-key.user-id` is 123 via the `default_context`
- `cpu.count` resolves to 4 via the `global_context`
