### PR TITLE
Remove iso8601 dep. Use custom parser.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'googleapis-common-protos-types', platforms: :ruby
 gem 'google-protobuf', platforms: :ruby
 gem 'ld-eventsource'
 gem 'uuid'
-gem 'iso8601'
 
 gem 'activesupport', '>= 4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     http-form_data (2.3.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    iso8601 (0.13.0)
     juwelier (2.4.9)
       builder
       bundler
@@ -164,7 +163,6 @@ DEPENDENCIES
   faraday
   google-protobuf
   googleapis-common-protos-types
-  iso8601
   juwelier (~> 2.4.9)
   ld-eventsource
   minitest

--- a/lib/prefab/duration.rb
+++ b/lib/prefab/duration.rb
@@ -1,15 +1,26 @@
 # frozen_string_literal: true
 
-require 'iso8601'
-
 module Prefab
   class Duration
+    PATTERN = /P(?:(?<days>\d+(?:\.\d+)?)D)?(?:T(?:(?<hours>\d+(?:\.\d+)?)H)?(?:(?<minutes>\d+(?:\.\d+)?)M)?(?:(?<seconds>\d+(?:\.\d+)?)S)?)?/
+    MINUTES_IN_SECONDS = 60
+    HOURS_IN_SECONDS = 60 * MINUTES_IN_SECONDS
+    DAYS_IN_SECONDS = 24 * HOURS_IN_SECONDS
+
     def initialize(definition)
       @seconds = self.class.parse(definition)
     end
 
     def self.parse(definition)
-      ISO8601::Duration.new(definition).to_seconds
+      match = PATTERN.match(definition)
+      return 0 unless match
+
+      days = match[:days]&.to_f || 0
+      hours = match[:hours]&.to_f || 0
+      minutes = match[:minutes]&.to_f || 0
+      seconds = match[:seconds]&.to_f || 0
+
+      (days * DAYS_IN_SECONDS + hours * HOURS_IN_SECONDS + minutes * MINUTES_IN_SECONDS + seconds)
     end
 
     def in_seconds

--- a/test/test_duration.rb
+++ b/test/test_duration.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DurationTest < Minitest::Test
+  MINUTES_IN_SECONDS = 60
+  HOURS_IN_SECONDS = 60 * MINUTES_IN_SECONDS
+  DAYS_IN_SECONDS = 24 * HOURS_IN_SECONDS
+
+  TESTS = [
+    ['PT0M0S', 0],
+    ['PT6M', 6 * MINUTES_IN_SECONDS],
+    ['PT90S', 90],
+    ['P1D', DAYS_IN_SECONDS],
+    ['PT1.5M', 1.5 * MINUTES_IN_SECONDS],
+    ['P0.75D', 0.75 * DAYS_IN_SECONDS],
+    ['PT1M90.3S', MINUTES_IN_SECONDS + 90.3],
+    ['PT1H', HOURS_IN_SECONDS],
+    ['PT1.3H', 1.3 * HOURS_IN_SECONDS],
+    ['P1.5DT1.5M', 1.5 * DAYS_IN_SECONDS + MINUTES_IN_SECONDS * 1.5],
+    ['P1.5DT1.5H1.5M', 1.5 * DAYS_IN_SECONDS + 1.5 * HOURS_IN_SECONDS + MINUTES_IN_SECONDS * 1.5],
+    ['P1.5DT1.5H1.5M3.5S', 1.5 * DAYS_IN_SECONDS + 1.5 * HOURS_IN_SECONDS + MINUTES_IN_SECONDS * 1.5 + 3.5],
+    ['P1DT2H3M4S', DAYS_IN_SECONDS + 2 * HOURS_IN_SECONDS + 3 * MINUTES_IN_SECONDS + 4],
+    ['PT1H30M', HOURS_IN_SECONDS + 30 * MINUTES_IN_SECONDS],
+    ['P0.5DT0.25H', 0.5 * DAYS_IN_SECONDS + 0.25 * HOURS_IN_SECONDS],
+    ['PT15M30S', 15 * MINUTES_IN_SECONDS + 30],
+    ['PT0.000347222H', 0.000347222 * HOURS_IN_SECONDS],
+    ['PT23H59M59S', 23 * HOURS_IN_SECONDS + 59 * MINUTES_IN_SECONDS + 59],
+    ['P0.25DT3.75H', 0.25 * DAYS_IN_SECONDS + 3.75 * HOURS_IN_SECONDS],
+  ]
+
+  def test_parsing
+    TESTS.each do |test|
+      assert_equal test[1], Prefab::Duration.parse(test[0]), "Failed parsing #{test[0]}"
+    end
+  end
+end


### PR DESCRIPTION
Our usage is simple enough that we can avoid a dependency here.
