### PR TITLE
Ensure we use top-level UUID

### DIFF
--- a/lib/prefab/client.rb
+++ b/lib/prefab/client.rb
@@ -14,7 +14,7 @@ module Prefab
       @options = options.is_a?(Prefab::Options) ? options : Prefab::Options.new(options)
       @namespace = @options.namespace
       @stubs = {}
-      @instance_hash = UUID.new.generate
+      @instance_hash = ::UUID.new.generate
 
       if @options.local_only?
         LOG.debug 'Prefab Running in Local Mode'


### PR DESCRIPTION
There was no conflict here, but this should make the error message
clearer in cases where the consumer defines their own UUID class.

The error will report as `UUID`, rather than `Prefab::Client::UUID`
