### PR TITLE
idea for a migration assistant helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ on_worker_boot do
 end
 ```
 
+## Migrating to Prefab
+```ruby
+#config/application.rb
+LegacyFeatureFlagProvider.init
+Prefab.init(migration_fallback: (key, default=nil) -> LegacyFeatureFlagProvider.get(key, default))
+
+#controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  around_action do |_, block|
+    LegacyFeatureFlagProvider.set_context(context)
+    Prefab.with_context(context, &block)
+  end
+
+#models/my_model.rb
+# Prefab.get("key") will look in Prefab, if no key is found it will call the migration_fallback
++ Prefab.get("key") 
+- LegacyFeatureFlagProvider.get("key")
+```
+
+
 ## Contributing to prefab-cloud-ruby
 
 - Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.

--- a/lib/prefab/config_client.rb
+++ b/lib/prefab/config_client.rb
@@ -94,8 +94,16 @@ module Prefab
     def raw(key)
       @config_resolver.raw(key)
     end
-
+    
     def handle_default(key, default)
+      if @options.migration_fallback
+        if default == NO_DEFAULT_PROVIDED
+          return @options.migration_fallback.call(key)
+        else
+          return @options.migration_fallback.call(key, default)
+        end
+      end
+
       return default if default != NO_DEFAULT_PROVIDED
 
       raise Prefab::Errors::MissingDefaultError, key if @options.on_no_default == Prefab::Options::ON_NO_DEFAULT::RAISE

--- a/lib/prefab/options.rb
+++ b/lib/prefab/options.rb
@@ -19,6 +19,7 @@ module Prefab
     attr_reader :use_local_cache
     attr_reader :datafile
     attr_reader :global_context
+    attr_reader :migration_fallback # Add migration attribute reader
     attr_accessor :is_fork
 
     module ON_INITIALIZATION_FAILURE
@@ -68,7 +69,8 @@ module Prefab
       allow_telemetry_in_local_mode: false,
       x_datafile: ENV['PREFAB_DATAFILE'],
       x_use_local_cache: false,
-      global_context: {}
+      global_context: {},
+      migration_fallback: nil # Add migration parameter with default value
     )
       @api_key = api_key
       @namespace = namespace
@@ -89,6 +91,7 @@ module Prefab
       @use_local_cache = x_use_local_cache
       @is_fork = false
       @global_context = global_context
+      @migration_fallback = migration_fallback # Initialize migration attribute
 
       # defaults that may be overridden by context_upload_mode
       @collect_shapes = false

--- a/test/test_config_client_migration.rb
+++ b/test/test_config_client_migration.rb
@@ -28,14 +28,7 @@ class TestConfigClientMigration < Minitest::Test
   def test_migration_value
     assert_equal 'fallback value', @config_client.get('exists in fallback')
     assert_equal 'fallback value', @config_client.get('exists in fallback', "unused default")
-    assert_equal nil, @config_client.get("doesn't exist in fallback")
-    assert_equal 'default value', @config_client.get("doesn't exist in fallback", "default value")
-  end
-  
-  def test_booleans
-    assert_equal 'fallback value', @config_client.get('exists in fallback')
-    assert_equal 'fallback value', @config_client.get('exists in fallback', "unused default")
-    assert_equal nil, @config_client.get("doesn't exist in fallback")
+    assert_nil @config_client.get("doesn't exist in fallback")
     assert_equal 'default value', @config_client.get("doesn't exist in fallback", "default value")
   end
 end

--- a/test/test_config_client_migration.rb
+++ b/test/test_config_client_migration.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PretendLdClient
+  def get(key, default)
+    return "fallback value" if key == "exists in fallback"
+    return default if key == "doesn't exist in fallback"
+  end
+end
+
+class TestConfigClientMigration < Minitest::Test
+  def setup
+    super
+
+    options = Prefab::Options.new(
+      prefab_config_override_dir: 'none',
+      prefab_config_classpath_dir: 'test',
+      prefab_envs: 'unit_tests',
+      prefab_datasources: Prefab::Options::DATASOURCES::LOCAL_ONLY,
+      x_use_local_cache: true,
+      migration_fallback: -> (key, default=nil) { PretendLdClient.new.get(key, default) }
+    )
+
+    @config_client = Prefab::ConfigClient.new(MockBaseClient.new(options), 10)
+  end
+
+  def test_migration_value
+    assert_equal 'fallback value', @config_client.get('exists in fallback')
+    assert_equal 'fallback value', @config_client.get('exists in fallback', "unused default")
+    assert_equal nil, @config_client.get("doesn't exist in fallback")
+    assert_equal 'default value', @config_client.get("doesn't exist in fallback", "default value")
+  end
+  
+  def test_booleans
+    assert_equal 'fallback value', @config_client.get('exists in fallback')
+    assert_equal 'fallback value', @config_client.get('exists in fallback', "unused default")
+    assert_equal nil, @config_client.get("doesn't exist in fallback")
+    assert_equal 'default value', @config_client.get("doesn't exist in fallback", "default value")
+  end
+end


### PR DESCRIPTION
## Migrating to Prefab

Idea is that you can use this to ease transition to Prefab. 

1. Do this setup

```ruby
#config/application.rb
LegacyFeatureFlagProvider.init
Prefab.init(migration_fallback: (key, default=nil) -> LegacyFeatureFlagProvider.get(key, default))

#controllers/application_controller.rb
class ApplicationController < ActionController::Base
  around_action do |_, block|
    LegacyFeatureFlagProvider.set_context(context)
    Prefab.with_context(context, &block)
  end
```

2. Migrate code to call `Prefab.get()`
```ruby
#models/my_model.rb
# Prefab.get("key") will look in Prefab, if no key is found it will call the migration_fallback
+ Prefab.get("key") 
- LegacyFeatureFlagProvider.get("key")
```

3. Migrate flags at your leisure to Prefab. 
4. Once you see no evaluations in LegacyFeatureFlagProvider, cut over. 