### PR TITLE
Update version matrix - remove 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.3']
+        ruby-version: ['3.0','3.1','3.2','3.3']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
update the version matrix for tests.
removes 2.7, keeps current versions plus 3.0 (for now)