### PR TITLE
Add regex-match support

### DIFF
--- a/lib/prefab/criteria_evaluator.rb
+++ b/lib/prefab/criteria_evaluator.rb
@@ -194,11 +194,29 @@ module Prefab
         return MatchResult.error unless regex_definition.is_a?(String)
 
         value = value_from_properties(criterion, properties)
-        matches = Regexp.new("^#{regex_definition}$").match?(value.to_s)
+
+        regex = compile_regex_safely(ensure_anchored_regex(regex_definition))
+        return MatchResult.error unless regex
+
+        matches = regex.match?(value.to_s)
         matches ? MatchResult.matched : MatchResult.not_matched
       rescue RegexpError
         MatchResult.error
       end
+    end
+
+    def compile_regex_safely(pattern)
+      begin
+        Regexp.new(pattern)
+      rescue RegexpError
+        nil
+      end
+    end
+
+    def ensure_anchored_regex(pattern)
+      return pattern if pattern.start_with?("^") && pattern.end_with?("$")
+
+      "^#{pattern}$"
     end
 
     class MatchResult

--- a/lib/prefab/criteria_evaluator.rb
+++ b/lib/prefab/criteria_evaluator.rb
@@ -21,7 +21,7 @@ module Prefab
 
     def evaluate(properties)
       rtn = evaluate_for_env(@project_env_id, properties) ||
-            evaluate_for_env(0, properties)
+        evaluate_for_env(0, properties)
       LOG.trace {
         "Eval Key #{@config.key} Result #{rtn&.reportable_value} with #{properties.to_h}"
       } unless @config.config_type == :LOG_LEVEL
@@ -95,6 +95,24 @@ module Prefab
       value && value >= criterion.value_to_match.int_range.start && value < criterion.value_to_match.int_range.end
     end
 
+    def PROP_MATCHES(criterion, properties)
+      result = check_regex_match(criterion, properties)
+      if result.error
+        false
+      else
+        result.matched
+      end
+    end
+
+    def PROP_DOES_NOT_MATCH(criterion, properties)
+      result = check_regex_match(criterion, properties)
+      if result.error
+        false
+      else
+        !result.matched
+      end
+    end
+
     def value_from_properties(criterion, properties)
       criterion.property_name == NAMESPACE_KEY ? @namespace : properties.get(criterion.property_name)
     end
@@ -165,6 +183,42 @@ module Prefab
 
       criterion.value_to_match.string_list.values.any? do |substring|
         value.include?(substring)
+      end
+    end
+
+    def check_regex_match(criterion, properties)
+      begin
+        regex_definition = Prefab::ConfigValueUnwrapper.deepest_value(criterion.value_to_match, @config.key,
+                                                                      properties, @resolver).unwrap
+
+        return MatchResult.error unless regex_definition.is_a?(String)
+
+        value = value_from_properties(criterion, properties)
+        matches = Regexp.new("^#{regex_definition}$").match?(value.to_s)
+        matches ? MatchResult.matched : MatchResult.not_matched
+      rescue RegexpError
+        MatchResult.error
+      end
+    end
+
+    class MatchResult
+      attr_reader :matched, :error
+
+      def self.matched
+        new(matched: true)
+      end
+
+      def self.not_matched
+        new(matched: false)
+      end
+
+      def self.error
+        new(matched: false, error: true)
+      end
+
+      def initialize(matched:, error: false)
+        @matched = matched
+        @error = error
       end
     end
   end

--- a/test/support/common_helpers.rb
+++ b/test/support/common_helpers.rb
@@ -174,18 +174,17 @@ module CommonHelpers
   end
 
   def assert_stderr(expected)
-    assert ($stderr.string.split("\n").uniq & expected).size > 0
+    $stderr.string.split("\n").uniq.each do |line|
+      matched = false
 
-    # Ruby 2.X has a lot of warnings about instance variables not being
-    # initialized so we don't try to assert on stderr for those versions.
-    # Instead we just stop after asserting that our expected errors are
-    # included in the output.
-    if RUBY_VERSION.start_with?('2.')
-      puts $stderr.string
-      return
+      expected.reject! do |expectation|
+        matched = true if line.include?(expectation)
+      end
+
+      assert(matched, "expectation: #{expected}, got: #{line}")
     end
 
-    assert_equal expected.uniq, $stderr.string.split("\n").uniq
+    assert expected.empty?, "Expected stderr to include: #{expected}, but it did not"
 
     # restore since we've handled it
     $stderr = $oldstderr

--- a/test/test_criteria_evaluator.rb
+++ b/test/test_criteria_evaluator.rb
@@ -895,11 +895,10 @@ class TestCriteriaEvaluator < Minitest::Test
 
     evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
                                               namespace: nil)
-    #silencing stderr because of "warning: character class has duplicated range: /^[a+b+$/"
-    silence_stderr do
-     assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
-     assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
-    end
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+
+    assert_stderr [ "warning: character class has duplicated range: /^[a+b+$/" ]
   end
 
 
@@ -928,24 +927,14 @@ class TestCriteriaEvaluator < Minitest::Test
 
     evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
                                               namespace: nil)
-    #silencing stderr because of "warning: character class has duplicated range: /^[a+b+$/"
 
-    silence_stderr do
-      assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
-      assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
-    end
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
 
+    assert_stderr [ "warning: character class has duplicated range: /^[a+b+$/" ]
   end
 
   private
-
-  def silence_stderr
-    original_stderr = $stderr
-    $stderr = File.open(File::NULL, "w")  # Redirect STDERR to null
-    yield
-  ensure
-    $stderr = original_stderr  # Restore STDERR after execution
-  end
 
   def string_list(values)
     PrefabProto::ConfigValue.new(string_list: PrefabProto::StringList.new(values: values))

--- a/test/test_criteria_evaluator.rb
+++ b/test/test_criteria_evaluator.rb
@@ -808,6 +808,131 @@ class TestCriteriaEvaluator < Minitest::Test
     assert_equal 'ghi', evaluator.evaluate(context).unwrapped_value
   end
 
+  def test_prop_regex_matches
+    config = PrefabProto::Config.new(
+      key: KEY,
+      rows: [
+        DEFAULT_ROW,
+        PrefabProto::ConfigRow.new(
+          project_env_id: PROJECT_ENV_ID,
+          values: [
+            PrefabProto::ConditionalValue.new(
+              criteria: [
+                PrefabProto::Criterion.new(
+                  operator: PrefabProto::Criterion::CriterionOperator::PROP_MATCHES,
+                  value_to_match: PrefabProto::ConfigValue.new(string: "a+b+"),
+                  property_name: 'user.testProperty'
+                )
+              ],
+              value: DESIRED_VALUE_CONFIG
+            )
+          ]
+        )
+      ]
+    )
+
+    evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
+                                              namespace: nil)
+
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+    assert_equal DESIRED_VALUE, evaluator.evaluate(context(user: { testProperty: 'aabb' })).unwrapped_value
+  end
+
+  def test_prop_regex_does_not_match
+    config = PrefabProto::Config.new(
+      key: KEY,
+      rows: [
+        DEFAULT_ROW,
+        PrefabProto::ConfigRow.new(
+          project_env_id: PROJECT_ENV_ID,
+          values: [
+            PrefabProto::ConditionalValue.new(
+              criteria: [
+                PrefabProto::Criterion.new(
+                  operator: PrefabProto::Criterion::CriterionOperator::PROP_DOES_NOT_MATCH,
+                  value_to_match: PrefabProto::ConfigValue.new(string: "a+b+"),
+                  property_name: 'user.testProperty'
+                )
+              ],
+              value: DESIRED_VALUE_CONFIG
+            )
+          ]
+        )
+      ]
+    )
+
+    evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
+                                              namespace: nil)
+
+    assert_equal DESIRED_VALUE, evaluator.evaluate(context({})).unwrapped_value
+    assert_equal DESIRED_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'aabb' })).unwrapped_value
+  end
+
+  def test_prop_regex_does_not_match_returns_false_bad_regex
+    config = PrefabProto::Config.new(
+      key: KEY,
+      rows: [
+        DEFAULT_ROW,
+        PrefabProto::ConfigRow.new(
+          project_env_id: PROJECT_ENV_ID,
+          values: [
+            PrefabProto::ConditionalValue.new(
+              criteria: [
+                PrefabProto::Criterion.new(
+                  operator: PrefabProto::Criterion::CriterionOperator::PROP_DOES_NOT_MATCH,
+                  value_to_match: PrefabProto::ConfigValue.new(string: "[a+b+"),
+                  property_name: 'user.testProperty'
+                )
+              ],
+              value: DESIRED_VALUE_CONFIG
+            )
+          ]
+        )
+      ]
+    )
+
+    evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
+                                              namespace: nil)
+
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+
+  end
+
+
+  def test_prop_regex_match_returns_false_bad_regex
+    config = PrefabProto::Config.new(
+      key: KEY,
+      rows: [
+        DEFAULT_ROW,
+        PrefabProto::ConfigRow.new(
+          project_env_id: PROJECT_ENV_ID,
+          values: [
+            PrefabProto::ConditionalValue.new(
+              criteria: [
+                PrefabProto::Criterion.new(
+                  operator: PrefabProto::Criterion::CriterionOperator::PROP_MATCHES,
+                  value_to_match: PrefabProto::ConfigValue.new(string: "[a+b+"),
+                  property_name: 'user.testProperty'
+                )
+              ],
+              value: DESIRED_VALUE_CONFIG
+            )
+          ]
+        )
+      ]
+    )
+
+    evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
+                                              namespace: nil)
+
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+
+  end
+
   private
 
   def string_list(values)

--- a/test/test_criteria_evaluator.rb
+++ b/test/test_criteria_evaluator.rb
@@ -895,10 +895,11 @@ class TestCriteriaEvaluator < Minitest::Test
 
     evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
                                               namespace: nil)
-
-    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
-    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
-
+    #silencing stderr because of "warning: character class has duplicated range: /^[a+b+$/"
+    silence_stderr do
+     assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+     assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+    end
   end
 
 
@@ -927,13 +928,24 @@ class TestCriteriaEvaluator < Minitest::Test
 
     evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client,
                                               namespace: nil)
+    #silencing stderr because of "warning: character class has duplicated range: /^[a+b+$/"
 
-    assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
-    assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+    silence_stderr do
+      assert_equal DEFAULT_VALUE, evaluator.evaluate(context({})).unwrapped_value
+      assert_equal DEFAULT_VALUE, evaluator.evaluate(context(user: { testProperty: 'abc' })).unwrapped_value
+    end
 
   end
 
   private
+
+  def silence_stderr
+    original_stderr = $stderr
+    $stderr = File.open(File::NULL, "w")  # Redirect STDERR to null
+    yield
+  ensure
+    $stderr = original_stderr  # Restore STDERR after execution
+  end
 
   def string_list(values)
     PrefabProto::ConfigValue.new(string_list: PrefabProto::StringList.new(values: values))


### PR DESCRIPTION
## Description
This adds regex match/not-match operator support

## Testing & Validation
There are unit tests here. Additional testing will be done by updating the integration test suite when all new operators are implemented
