### PR TITLE
Update stderr manipulation code in test helper

### DIFF
--- a/test/support/common_helpers.rb
+++ b/test/support/common_helpers.rb
@@ -191,5 +191,8 @@ module CommonHelpers
     end
 
     assert expected.empty?, "Expected stderr to include: #{expected}, but it did not"
+
+    # restore since we've handled it
+    $stderr = $oldstderr
   end
 end


### PR DESCRIPTION
## Description
Update stderr manipulation code in test helper
running in an IDE causes this code to fail, so instead its safely neutered with this approach.

errors like

```
Minitest::UnexpectedError: NoMethodError: undefined method `string' for #<IO:<STDERR>>
    test/support/common_helpers.rb:29:in `teardown'
.../common_helpers.rb:29:in `teardown'
```

I think we could use IO.pipes or something so that everyone can read the stderr together but this is simple 

## Testing & Validation
Run the tests


