### PR TITLE
Update prefab.current time implementation

### DIFF
--- a/lib/prefab/context.rb
+++ b/lib/prefab/context.rb
@@ -200,12 +200,6 @@ module Prefab
     end
 
     def to_proto(namespace)
-      prefab_context = {
-        'current-time' => ConfigValueWrapper.wrap(Prefab::TimeHelpers.now_in_ms)
-      }
-
-      prefab_context['namespace'] = ConfigValueWrapper.wrap(namespace) if namespace&.length&.positive?
-
       reportable_contexts = {}
 
       reportable_tree.each do |ctx|
@@ -217,8 +211,7 @@ module Prefab
       PrefabProto::ContextSet.new(
         contexts: reportable_contexts.map do |name, context|
           context.to_proto
-        end.concat([PrefabProto::Context.new(type: 'prefab',
-                                             values: prefab_context)])
+        end
       )
     end
 

--- a/lib/prefab/criteria_evaluator.rb
+++ b/lib/prefab/criteria_evaluator.rb
@@ -86,12 +86,7 @@ module Prefab
     end
 
     def IN_INT_RANGE(criterion, properties)
-      value = if criterion.property_name == 'prefab.current-time'
-                Time.now.utc.to_i * 1000
-              else
-                value_from_properties(criterion, properties)
-              end
-
+      value = value_from_properties(criterion, properties)
       value && value >= criterion.value_to_match.int_range.start && value < criterion.value_to_match.int_range.end
     end
 
@@ -150,7 +145,14 @@ module Prefab
     end
 
     def value_from_properties(criterion, properties)
-      criterion.property_name == NAMESPACE_KEY ? @namespace : properties.get(criterion.property_name)
+      case criterion.property_name
+      when NAMESPACE_KEY
+        @namespace
+      when 'prefab.current-time'
+        Time.now.utc.to_i * 1000
+      else
+        properties.get(criterion.property_name)
+      end
     end
 
     COMPARE_TO_OPERATORS = {

--- a/test/support/common_helpers.rb
+++ b/test/support/common_helpers.rb
@@ -11,7 +11,6 @@ module CommonHelpers
     Prefab::Context.default_context.clear
     SemanticLogger.add_appender(io: $logs, filter: Prefab.log_filter)
     SemanticLogger.sync!
-    Timecop.freeze('2023-08-09 15:18:12 -0400')
   end
 
   def teardown

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -141,14 +141,6 @@ class TestContext < Minitest::Test
             "id" => PrefabProto::ConfigValue.new(int: 2),
             "name" => PrefabProto::ConfigValue.new(string: "team-name")
           }
-        ),
-
-        PrefabProto::Context.new(
-          type: "prefab",
-          values: {
-            'current-time' => PrefabProto::ConfigValue.new(int: Prefab::TimeHelpers.now_in_ms),
-            'namespace' => PrefabProto::ConfigValue.new(string: namespace)
-          }
         )
       ]
     ), contexts.to_proto(namespace)
@@ -226,13 +218,6 @@ class TestContext < Minitest::Test
             "name" => PrefabProto::ConfigValue.new(string: "team-name")
           }
         ),
-        # via to_proto
-        PrefabProto::Context.new(
-          type: "prefab",
-          values: {
-            'current-time' => PrefabProto::ConfigValue.new(int: Prefab::TimeHelpers.now_in_ms),
-          }
-        )
       ]
     )
 

--- a/test/test_criteria_evaluator.rb
+++ b/test/test_criteria_evaluator.rb
@@ -1068,6 +1068,28 @@ class TestCriteriaEvaluator < Minitest::Test
     assert_equal DESIRED_VALUE, evaluator.evaluate(context(user:{version: "3.0.0"})).unwrapped_value
   end
 
+  def test_date_before_with_current_time
+    future_time = Time.now.utc + 3600 # 1 hour in the future
+    config = create_prefab_config(
+      operator: PrefabProto::Criterion::CriterionOperator::PROP_BEFORE,
+      property_name: 'prefab.current-time',
+      value_to_match: future_time.iso8601
+    )
+    evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client, namespace: nil)
+    assert_equal DESIRED_VALUE, evaluator.evaluate(context({})).unwrapped_value
+  end
+
+  def test_date_after_with_current_time
+    past_time = Time.now.utc - 3600 # 1 hour in the past
+    config = create_prefab_config(
+      operator: PrefabProto::Criterion::CriterionOperator::PROP_AFTER,
+      property_name: 'prefab.current-time',
+      value_to_match: past_time.iso8601
+    )
+    evaluator = Prefab::CriteriaEvaluator.new(config, project_env_id: PROJECT_ENV_ID, resolver: nil, base_client: @base_client, namespace: nil)
+    assert_equal DESIRED_VALUE, evaluator.evaluate(context({})).unwrapped_value
+  end
+
   private
 
   def string_list(values)


### PR DESCRIPTION
## Description
This updates context handling so that the context "prefab.current-time" will always return the current time in epoch millis (UTC)


## Testing & Validation
New unit test cases plus two integration test cases cover this 


## Rollout
*(Optional section: Provide rollout and rollback procedures, when outside the bounds or requiring additional work beyond standard deployment)*
